### PR TITLE
SearchBox: Register for events at init

### DIFF
--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -175,11 +175,12 @@ public class Searcher {
     @NonNull
     public Searcher search(@Nullable final Intent intent) {
         String query = null;
+        Object origin = null;
         if (intent != null && Intent.ACTION_SEARCH.equals(intent.getAction())) {
             query = intent.getStringExtra(SearchManager.QUERY);
-            EventBus.getDefault().post(new QueryTextChangeEvent(query, intent));
+            origin = intent;
         }
-        return search(query);
+        return search(query, origin);
     }
 
     /**

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/SearchBox.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/SearchBox.java
@@ -3,6 +3,7 @@ package com.algolia.instantsearch.ui.views;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.SearchView;
 import android.util.AttributeSet;
 import android.view.inputmethod.EditorInfo;
@@ -17,7 +18,17 @@ import org.greenrobot.eventbus.Subscribe;
  * Provides a user input for search queries that are directly sent to the Algolia engine.
  */
 public class SearchBox extends SearchView {
-//DISCUSS: Do we impose a PoweredBy? Can we even display it correctly?
+    /**
+     * Constructs a new SearchBox with the given context's theme.
+     *
+     * @param context The Context the view is running in, through which it can
+     *                access the current theme, resources, etc.
+     */
+    public SearchBox(Context context) {
+        super(context);
+        init(context, null);
+    }
+
     /**
      * Constructs a new SearchBox with the given context's theme and the supplied attribute set.
      *
@@ -27,28 +38,34 @@ public class SearchBox extends SearchView {
      */
     public SearchBox(@NonNull Context context, @NonNull AttributeSet attrs) {
         super(context, attrs);
+        init(context, attrs);
+    }
+
+    private void init(@NonNull Context context, @Nullable AttributeSet attrs) {
         if (isInEditMode()) {
             return;
         }
 
-        final TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.SearchBox, 0, 0);
+        if (attrs != null) {
+            final TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.SearchBox, 0, 0);
 
-        try {
-            setIconifiedByDefault(false); // By default, don't collapse SearchBox
-            for (int i = 0; i < attrs.getAttributeCount(); i++) {
-                if ("iconifiedByDefault".equals(attrs.getAttributeName(i))) {
-                    setIconifiedByDefault(attrs.getAttributeBooleanValue(i, false)); // Unless iconifiedByDefault is set
+            try {
+                setIconifiedByDefault(false); // By default, don't collapse SearchBox
+                for (int i = 0; i < attrs.getAttributeCount(); i++) {
+                    if ("iconifiedByDefault".equals(attrs.getAttributeName(i))) {
+                        setIconifiedByDefault(attrs.getAttributeBooleanValue(i, false)); // Unless iconifiedByDefault is set
+                    }
                 }
-            }
 
-            if (styledAttributes.getBoolean(R.styleable.SearchBox_autofocus, false)) {
-                setFocusable(true);
-                setIconified(false);
-                requestFocusFromTouch();
+                if (styledAttributes.getBoolean(R.styleable.SearchBox_autofocus, false)) {
+                    setFocusable(true);
+                    setIconified(false);
+                    requestFocusFromTouch();
+                }
+                setSubmitButtonEnabled(styledAttributes.getBoolean(R.styleable.SearchBox_submitButtonEnabled, false));
+            } finally {
+                styledAttributes.recycle();
             }
-            setSubmitButtonEnabled(styledAttributes.getBoolean(R.styleable.SearchBox_submitButtonEnabled, false));
-        } finally {
-            styledAttributes.recycle();
         }
     }
 

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/SearchBox.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/SearchBox.java
@@ -46,6 +46,8 @@ public class SearchBox extends SearchView {
             return;
         }
 
+        EventBus.getDefault().register(this); // SearchBox needs to react to QueryTextChangeEvent before being attached
+
         if (attrs != null) {
             final TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(attrs, R.styleable.SearchBox, 0, 0);
 
@@ -99,7 +101,9 @@ public class SearchBox extends SearchView {
     @Override
     public void onAttachedToWindow() {
         super.onAttachedToWindow();
-        EventBus.getDefault().register(this);
+        if (!EventBus.getDefault().isRegistered(this)) {
+            EventBus.getDefault().register(this);
+        }
     }
 
     @Override


### PR DESCRIPTION
This was a required change to support the following interaction:

1. Search is triggered from another Activity to the SearchableActivity
2. `SearchBox` is initialized, but is in a `Menu` so is not attached to window yet
3. `Searcher` gets the search `Intent` and triggers the search, sending a `QueryTextChangeEvent`
4. The `SearchBox` gets attached to the screen, but does not display the query

With this change, the `SearchBox` registers at step 2, ensuring it updates its query.
I made sure to avoid double registration on EventBus.