### PR TITLE
Feat/multi index

### DIFF
--- a/docgen/src/widgets.md
+++ b/docgen/src/widgets.md
@@ -174,6 +174,21 @@ hits.setOnItemClickListener(new ItemClickSupport.OnItemClickListener() {
  });
 ```
 
+### Prefixing and suffixing attributes
+You might need to apply a prefix or suffix to a View's attribute value. A common use case is image attributes having only a relative path like `foo.png`, and requiring a prefix like `https://example.com/files/` to get the full image path.
+
+To achieve this, you can add either or both `prefix` / `suffix` attributes to your view. For example, if your attribute value is `foo` but you want the full value to be `https://example.com/files/foo.png`:
+```xml
+<ImageView
+    android:id="@+id/name"
+    algolia:attribute='@{"image"}'
+    algolia:prefix='@{"https://example.com/files/"}'
+    algolia:suffix='@{".png"}'/>
+```
+
+
+
+
 ### Highlighting
 <img src="assets/img/highlighting.png" class="img-object" align="right"/>
 

--- a/docgen/src/widgets.md
+++ b/docgen/src/widgets.md
@@ -189,7 +189,8 @@ The `Hits` widget automatically handles highlighting. To highlight a textual att
 ```
 This will highlight the attribute according to the query term, like you can see in the screenshot. The color used by default for highlighting is `R.color.colorHighlighting`, which you can override in your application.
 
-You can also specify `algolia:highlightingColor='@{"color/appDefinedColor"}'` on a `View` to use a specific color for this one only.
+You can also specify `algolia:highlightingColor='@{R.color.color_foo}'` on a `View` to use a specific color for this one only.
+
 
 Note that highlighting **only works automatically on TextViews**. if you implement a [custom hit view](widgets.html#custom-hit-views) or to highlight results received by your [custom widget](widgets.html#anatomy-of-an-algoliawidget), you should use the [`Highlighter`](javadoc/com/algolia/instantsearch/helpers/Highlighter.html).
 This tool will let you build a highlighted [`Spannable`](https://developer.android.com/reference/android/text/Spannable.html) from a search result and an optional highlight color:

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/CancelEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/CancelEvent.java
@@ -1,18 +1,24 @@
 package com.algolia.instantsearch.events;
 
+import android.support.annotation.NonNull;
+
+import com.algolia.instantsearch.helpers.Searcher;
 import com.algolia.search.saas.Request;
 
 /**
  * An event to let you react to cancellation of search requests.
  */
 @SuppressWarnings("WeakerAccess")
-public class CancelEvent {
+public class CancelEvent extends SearcherEvent {
     /** The request that has been cancelled.*/
-    public final Request request;
+    @NonNull public final Request request;
     /** the search request's identifier. */
-    public final Integer requestSeqNumber;
+    public final int requestSeqNumber;
 
-    public CancelEvent(final Request request, final Integer requestSeqNumber) {
+    public CancelEvent(@NonNull final Searcher searcher,
+                       @NonNull final Request request,
+                       int requestSeqNumber) {
+        super(searcher);
         this.request = request;
         this.requestSeqNumber = requestSeqNumber;
     }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/ErrorEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/ErrorEvent.java
@@ -1,5 +1,8 @@
 package com.algolia.instantsearch.events;
 
+import android.support.annotation.NonNull;
+
+import com.algolia.instantsearch.helpers.Searcher;
 import com.algolia.search.saas.AlgoliaException;
 import com.algolia.search.saas.Query;
 
@@ -7,26 +10,30 @@ import com.algolia.search.saas.Query;
  * An event to let you react to search errors.
  */
 @SuppressWarnings("WeakerAccess")
-public class ErrorEvent {
+public class ErrorEvent extends SearcherEvent {
     /** The error that was received. */
-    public final AlgoliaException error;
+    @NonNull public final AlgoliaException error;
     /** the Query that was sent with the search request. */
-    public final Query query;
+    @NonNull public final Query query;
     /** the search request's identifier. */
     public final int requestSeqNumber;
 
-    public ErrorEvent(final AlgoliaException error, final Query query, int requestSeqNumber) {
+    public ErrorEvent(@NonNull final Searcher searcher,
+                      @NonNull final AlgoliaException error,
+                      @NonNull final Query query,
+                      int requestSeqNumber) {
+        super(searcher);
         this.error = error;
         this.query = query;
         this.requestSeqNumber = requestSeqNumber;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return "ErrorEvent{" +
-                "requestSeqNumber=" + requestSeqNumber +
-                ", query=" + query +
+                "searcher=" + searcher +
                 ", error=" + error +
+                ", query=" + query +
+                ", requestSeqNumber=" + requestSeqNumber +
                 '}';
     }
 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/FacetRefinementEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/FacetRefinementEvent.java
@@ -2,24 +2,37 @@ package com.algolia.instantsearch.events;
 
 import android.support.annotation.NonNull;
 
+import com.algolia.instantsearch.helpers.Searcher;
+
+/**
+ * An event to let you react to refinement of faceted attributes.
+ */
 public class FacetRefinementEvent extends RefinementEvent {
 
     /** The refining value. */
-    public @NonNull String value;
+    @NonNull public String value;
+
+    /** if {@code true}, this facet is a disjunctive refinement. */
+    @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
     public boolean isDisjunctive;
 
-    public FacetRefinementEvent(final @NonNull Operation operation, final @NonNull String attribute, final @NonNull String value, boolean isDisjunctive) {
-        super(operation, attribute);
+    public FacetRefinementEvent(final @NonNull Searcher searcher,
+                                final @NonNull Operation operation,
+                                final @NonNull String attribute,
+                                final @NonNull String value,
+                                boolean isDisjunctive) {
+        super(searcher, operation, attribute);
         this.value = value;
         this.isDisjunctive = isDisjunctive;
     }
 
     @Override public String toString() {
         return "FacetRefinementEvent{" +
-                "operation=" + operation +
-                ", attribute='" + attribute + '\'' +
-                ", value=" + value + '\'' +
+                "searcher=" + searcher +
+                ", value='" + value + '\'' +
                 ", isDisjunctive=" + isDisjunctive +
+                ", attribute='" + attribute + '\'' +
+                ", operation=" + operation +
                 '}';
     }
 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/NumericRefinementEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/NumericRefinementEvent.java
@@ -2,17 +2,23 @@ package com.algolia.instantsearch.events;
 
 import android.support.annotation.NonNull;
 
+import com.algolia.instantsearch.helpers.Searcher;
 import com.algolia.instantsearch.model.NumericRefinement;
 
+/**
+ * An event to let you react to refinement of numerical attributes.
+ */
 public class NumericRefinementEvent extends RefinementEvent {
 
     /** A description of the refinement: {@link NumericRefinement#attribute attribute}
      * is refined with {@link NumericRefinement#value value}
      * using {@link NumericRefinement#operator operator}. */
-    public @NonNull final NumericRefinement refinement;
+    @NonNull public final NumericRefinement refinement;
 
-    public NumericRefinementEvent(final @NonNull Operation operation, final @NonNull NumericRefinement refinement) {
-        super(operation, refinement.attribute);
+    public NumericRefinementEvent(final @NonNull Searcher searcher,
+                                  final @NonNull Operation operation,
+                                  final @NonNull NumericRefinement refinement) {
+        super(searcher, operation, refinement.attribute);
         this.refinement = refinement;
     }
 

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/QueryTextChangeEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/QueryTextChangeEvent.java
@@ -10,9 +10,9 @@ import android.support.annotation.Nullable;
 @SuppressWarnings("WeakerAccess")
 public class QueryTextChangeEvent {
     /** The new query string. */
-    public final @NonNull String query;
+    @NonNull public final String query;
     /** The origin of the change. Can be a SearchView, an Intent, or a Searcher. */
-    public @Nullable final Object origin;
+    @Nullable public final Object origin;
 
     public QueryTextChangeEvent(final @NonNull String query, @Nullable Object origin) {
         this.query = query;

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/QueryTextChangeEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/QueryTextChangeEvent.java
@@ -11,7 +11,7 @@ import android.support.annotation.Nullable;
 public class QueryTextChangeEvent {
     /** The new query string. */
     public final @NonNull String query;
-    /** The origin of the change. */
+    /** The origin of the change. Can be a SearchView, an Intent, or a Searcher. */
     public @Nullable final Object origin;
 
     public QueryTextChangeEvent(final @NonNull String query, @Nullable Object origin) {

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/RefinementEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/RefinementEvent.java
@@ -2,11 +2,13 @@ package com.algolia.instantsearch.events;
 
 import android.support.annotation.NonNull;
 
+import com.algolia.instantsearch.helpers.Searcher;
+
 /**
  * An event to let you react to refinement of the search parameters.
  */
 @SuppressWarnings("WeakerAccess")
-public class RefinementEvent {
+public class RefinementEvent extends SearcherEvent {
     /** An operation applied to the state of refinements. */
     public enum Operation {
         /** A new refinement is applied. */
@@ -16,19 +18,24 @@ public class RefinementEvent {
     }
 
     /** The attribute that is being refined. */
-    public @NonNull final String attribute;
+    @NonNull public final String attribute;
     /** Either {@link Operation#ADD ADD} (adding a new refinement) or {@link Operation#REMOVE REMOVE} (removing a current refinement). */
-    public @NonNull final Operation operation;
+    @NonNull public final Operation operation;
 
-    public RefinementEvent(final @NonNull Operation operation, final @NonNull String attribute) {
+
+    public RefinementEvent(@NonNull Searcher searcher,
+                           final @NonNull Operation operation,
+                           final @NonNull String attribute) {
+        super(searcher);
         this.attribute = attribute;
         this.operation = operation;
     }
 
     @Override public String toString() {
         return "RefinementEvent{" +
-                "operation=" + operation +
+                "searcher=" + searcher +
                 ", attribute='" + attribute + '\'' +
+                ", operation=" + operation +
                 '}';
     }
 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/ResetEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/ResetEvent.java
@@ -1,7 +1,20 @@
 package com.algolia.instantsearch.events;
 
+import android.support.annotation.NonNull;
+
+import com.algolia.instantsearch.helpers.Searcher;
+
 /**
  * An event to let you react to resetting of the search interface.
  */
-public class ResetEvent {
+public class ResetEvent extends SearcherEvent {
+    public ResetEvent(@NonNull Searcher searcher) {
+        super(searcher);
+    }
+
+    @Override public String toString() {
+        return "ResetEvent{" +
+                "searcher=" + searcher +
+                '}';
+    }
 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/ResultEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/ResultEvent.java
@@ -1,5 +1,8 @@
 package com.algolia.instantsearch.events;
 
+import android.support.annotation.NonNull;
+
+import com.algolia.instantsearch.helpers.Searcher;
 import com.algolia.instantsearch.model.SearchResults;
 import com.algolia.search.saas.Query;
 
@@ -9,28 +12,32 @@ import org.json.JSONObject;
  * An event to let you react to new search results.
  */
 @SuppressWarnings("WeakerAccess")
-public class ResultEvent {
+public class ResultEvent extends SearcherEvent {
     /** the search results. */
-    public final SearchResults results;
+    @NonNull public final SearchResults results;
     /** the Query that was sent with the search request. */
-    public final Query query;
+    @NonNull public final Query query;
     /** the search request's identifier. */
     public final int requestSeqNumber;
 
     public static final int REQUEST_UNKNOWN = -1;
 
-    public ResultEvent(final JSONObject json, final Query query, final int requestSeqNumber) {
+    public ResultEvent(@NonNull final Searcher searcher,
+                       @NonNull final JSONObject json,
+                       @NonNull final Query query,
+                       final int requestSeqNumber) {
+        super(searcher);
         this.results = new SearchResults(json);
         this.query = query;
         this.requestSeqNumber = requestSeqNumber;
     }
 
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return "ResultEvent{" +
-                "requestSeqNumber=" + requestSeqNumber +
-                ", content=" + results +
+                "searcher=" + searcher +
+                ", results=" + results +
                 ", query=" + query +
+                ", requestSeqNumber=" + requestSeqNumber +
                 '}';
     }
 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/SearchEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/SearchEvent.java
@@ -1,18 +1,24 @@
 package com.algolia.instantsearch.events;
 
+import android.support.annotation.NonNull;
+
+import com.algolia.instantsearch.helpers.Searcher;
 import com.algolia.search.saas.Query;
 
 /**
  * An event to let you react to new search requests.
  */
 @SuppressWarnings("WeakerAccess")
-public class SearchEvent {
+public class SearchEvent extends SearcherEvent {
     /** the Query that was sent with the search request. */
-    public final Query query;
+    @NonNull public final Query query;
     /** the search request's identifier. */
     public final int requestSeqNumber;
 
-    public SearchEvent(final Query query, final int requestSeqNumber) {
+    public SearchEvent(@NonNull Searcher searcher,
+                       @NonNull final Query query,
+                       final int requestSeqNumber) {
+        super(searcher);
         this.query = query;
         this.requestSeqNumber = requestSeqNumber;
     }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/events/SearcherEvent.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/events/SearcherEvent.java
@@ -1,0 +1,15 @@
+package com.algolia.instantsearch.events;
+
+import android.support.annotation.NonNull;
+
+import com.algolia.instantsearch.helpers.Searcher;
+
+/** An event that is triggered by a Searcher instance. */
+abstract class SearcherEvent {
+    /** The Searcher that triggered this event. */
+    @NonNull public final Searcher searcher;
+
+    SearcherEvent(@NonNull Searcher searcher) {
+        this.searcher = searcher;
+    }
+}

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Highlighter.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Highlighter.java
@@ -118,13 +118,14 @@ public class Highlighter {
      *
      * @param result    {@link JSONObject} describing a hit.
      * @param attribute name of the attribute to be highlighted.
-     * @param colorId   a resource Id referencing a color.
+     * @param colorRes   a resource Id referencing a color.
      * @param context   a {@link Context} to get resources from.
      * @return a {@link Spannable} with the highlighted text.
      */
     @Nullable
-    public Spannable renderHighlightColor(@NonNull JSONObject result, String attribute, @ColorRes int colorId, @NonNull Context context) {
-        return renderHighlightColor(getHighlightedAttribute(result, attribute), colorId, context);
+    @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
+    public Spannable renderHighlightColor(@NonNull JSONObject result, String attribute, @ColorRes int colorRes, @NonNull Context context) {
+        return renderHighlightColor(getHighlightedAttribute(result, attribute), getColor(context, colorRes));
     }
 
     /**
@@ -164,8 +165,8 @@ public class Highlighter {
      */
     @Nullable
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
-    public Spannable renderHighlightColor(String markupString, @ColorRes int colorId, @NonNull Context context) {
-        return renderHighlightColor(markupString, getColor(context, colorId));
+    public Spannable renderHighlightColor(String markupString, @ColorInt int colorId, @NonNull Context context) {
+        return renderHighlightColor(markupString, colorId);
     }
 
     /**
@@ -257,9 +258,8 @@ public class Highlighter {
         return JSONUtils.getStringFromJSONPath(result, attribute);
     }
 
-    private
     @ColorInt
-    int getColor(@NonNull Context context, @ColorRes int colorId) {
+    private int getColor(@NonNull Context context, @ColorRes int colorId) {
         final int colorHighlighting;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             colorHighlighting = context.getResources().getColor(colorId, context.getTheme());

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -223,8 +223,7 @@ public class InstantSearch {
 
 
     private void registerSearchView(@NonNull final Activity activity, @NonNull final SearchViewFacade searchView) {
-        this.searchBoxViewModel = new SearchBoxViewModel(searchView);
-        registerSearchView(activity, this.searchBoxViewModel);
+        registerSearchView(activity, new SearchBoxViewModel(searchView));
     }
 
     /**

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -33,6 +33,7 @@ import com.algolia.instantsearch.ui.views.SearchBox;
 import com.algolia.instantsearch.ui.views.filters.AlgoliaFilter;
 import com.algolia.instantsearch.utils.LayoutViews;
 import com.algolia.instantsearch.utils.SearchViewFacade;
+import com.algolia.search.saas.Query;
 
 import org.greenrobot.eventbus.EventBus;
 
@@ -170,7 +171,8 @@ public class InstantSearch {
      * @param query the text to search for.
      */
     public void search(String query) {
-        searcher.setQuery(searcher.getQuery().setQuery(query)).search();
+        final Query newQuery = searcher.getQuery().setQuery(query);
+        searcher.setQuery(newQuery).search();
     }
 
 

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -154,6 +154,16 @@ public class InstantSearch {
         registerSearchView(activity, new SearchViewFacade(searchView));
     }
 
+    private void registerSearchView(@NonNull Activity activity) {
+        View rootView = activity.getWindow().getDecorView().getRootView();
+        if (searchView == null) {
+            searchView = getSearchView(rootView);
+        }
+        if (searchView != null) {
+            registerSearchView(activity, searchView);
+        }
+    }
+
     private void registerSearchView(@NonNull final Activity activity, @NonNull final SearchViewFacade searchView) {
         this.searchView = searchView;
         final SearchManager searchManager = (SearchManager) searchView.getContext().getSystemService(Context.SEARCH_SERVICE);
@@ -280,15 +290,8 @@ public class InstantSearch {
     }
 
     private void processActivity(@NonNull final Activity activity) {
-        View rootView = activity.getWindow().getDecorView().getRootView();
-        if (searchView == null) {
-            searchView = getSearchView(rootView);
-        }
-        if (searchView != null) {
-            registerSearchView(activity, searchView);
-        }
-
-        final List<String> refinementAttributes = processAllListeners(rootView);
+        registerSearchView(activity);
+        final List<String> refinementAttributes = processAllListeners(activity.getWindow().getDecorView().getRootView());
         final String[] facets = refinementAttributes.toArray(new String[refinementAttributes.size()]);
         if (facets.length > 0) {
             searcher.addFacet(facets);

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.helpers;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.Fragment;
 import android.app.SearchManager;
 import android.content.Context;
 import android.os.Build;
@@ -71,9 +72,9 @@ public class InstantSearch {
     private int progressBarDelay = SearchProgressController.DEFAULT_DELAY;
 
     /**
-     * Constructs the helper, then link it to the given Activity.
+     * Constructs the helper, then link it to the given Activity and register its Widgets.
      *
-     * @param activity an Activity containing at least one {@link AlgoliaResultsListener} to update with incoming results.
+     * @param activity a searchable Activity containing at least one {@link AlgoliaResultsListener} to update with incoming results.
      * @param searcher the Searcher to use with this activity.
      */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
@@ -84,9 +85,9 @@ public class InstantSearch {
     }
 
     /**
-     * Constructs the helper, then link it to the given Activity and Menu's searchView.
+     * Constructs the helper, then link it to the given Activity and register its Widgets / its Menu's searchView.
      *
-     * @param activity   an Activity containing at least one {@link AlgoliaResultsListener} to update with incoming results.
+     * @param activity   a searchable Activity containing at least one {@link AlgoliaResultsListener} to update with incoming results.
      * @param menu       the Menu which contains your SearchView.
      * @param menuItemId the SearchView item's {@link android.support.annotation.IdRes id} in your Menu.
      * @param searcher   the Searcher to use with this activity.
@@ -99,12 +100,55 @@ public class InstantSearch {
         processActivity(activity);
     }
 
+    /**
+     * Constructs the helper, then link it to the given Activity and register its fragment's Widgets.
+     *
+     * @param activity a searchable Activity.
+     * @param fragment a Fragment containing at least one {@link AlgoliaResultsListener} to update with incoming results.
+     * @param searcher the Searcher to use with this activity.
+     */
+    @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
+    public InstantSearch(@NonNull final Activity activity, @NonNull final Searcher searcher, @NonNull Fragment fragment) {
+        this(searcher);
+
+        registerSearchView(activity);
+        processAllListeners(fragment.getView());
+    }
+
+    /**
+     * Constructs the helper, then link it to the given Activity and register its fragment's Widgets.
+     *
+     * @param activity a searchable Activity.
+     * @param fragment a Fragment containing at least one {@link AlgoliaResultsListener} to update with incoming results.
+     * @param searcher the Searcher to use with this activity.
+     */
+    @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
+    public InstantSearch(@NonNull final Activity activity, @NonNull final Searcher searcher, @NonNull android.support.v4.app.Fragment fragment) {
+        this(searcher);
+
+        registerSearchView(activity);
+        processAllListeners(fragment.getView());
+    }
+
+
+    /**
+     * Constructs the helper, then link it to the given Widget.
+     *
+     * @param widget   a Widget to register as listener.
+     * @param searcher the Searcher to use with this InstantSearch.
+     */
+    @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
     public InstantSearch(@NonNull final View widget, @NonNull final Searcher searcher) {
         this(searcher);
         registerWidget(widget);
     }
 
-    private InstantSearch(@NonNull final Searcher searcher) {
+    /**
+     * Constructs the helper.
+     *
+     * @param searcher the Searcher to use with this InstantSearch.
+     */
+    public InstantSearch(@NonNull final Searcher searcher) {
         this.searcher = searcher;
         enableProgressBar();
     }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -63,7 +63,6 @@ public class InstantSearch {
 
     private Menu searchMenu;
     private int searchMenuId;
-    private static int itemLayoutId = -42;
 
     private boolean showProgressBar;
     private SearchProgressController progressController;
@@ -256,20 +255,6 @@ public class InstantSearch {
     }
 
     /**
-     * Gets the {@link android.support.annotation.IdRes IdRes} of the item layout registered by a Hits widget.
-     * This method should only be used by the library's internals.
-     *
-     * @return the registered item layout id, if any.
-     * @throws IllegalStateException if no item layout was registered.
-     */
-    public static int getItemLayoutId() {
-        if (itemLayoutId == 0) {
-            throw new IllegalStateException(Errors.HITS_NO_ITEMLAYOUT);
-        }
-        return itemLayoutId;
-    }
-
-    /**
      * Enables or disables the sending of a search request when the SearchView becomes empty (default is true).
      *
      * @param searchOnEmptyString if {@code true}, a request will be fired.
@@ -401,9 +386,9 @@ public class InstantSearch {
                 // Link hits to activity's empty view //TODO: Remove rootView parameter if getRootView always works
                 ((Hits) widget).setEmptyView(getEmptyView(widget.getRootView()));
 
-                itemLayoutId = ((Hits) widget).getLayoutId();
+                int itemLayoutId = ((Hits) widget).getLayoutId();
 
-                if (itemLayoutId == -42) {
+                if (itemLayoutId == 0) {
                     throw new IllegalStateException(Errors.LAYOUT_MISSING_HITS_ITEMLAYOUT);
                 }
             } else if (widget instanceof RefinementList) {

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -26,6 +26,7 @@ import com.algolia.instantsearch.model.AlgoliaResultsListener;
 import com.algolia.instantsearch.model.AlgoliaSearcherListener;
 import com.algolia.instantsearch.model.Errors;
 import com.algolia.instantsearch.model.SearchBoxViewModel;
+import com.algolia.instantsearch.ui.databinding.BindingHelper;
 import com.algolia.instantsearch.ui.views.Hits;
 import com.algolia.instantsearch.ui.views.RefinementList;
 import com.algolia.instantsearch.ui.views.SearchBox;
@@ -389,34 +390,44 @@ public class InstantSearch {
     private List<String> processAllListeners(View rootView) {
         List<String> refinementAttributes = new ArrayList<>();
 
-        // Register any AlgoliaResultsListener
+        // Register any AlgoliaResultsListener (unless it has a different variant than searcher)
         final List<AlgoliaResultsListener> resultListeners = LayoutViews.findByClass((ViewGroup) rootView, AlgoliaResultsListener.class);
         if (resultListeners.size() == 0) {
             throw new IllegalStateException(Errors.LAYOUT_MISSING_RESULT_LISTENER);
         }
         for (AlgoliaResultsListener listener : resultListeners) {
             if (!this.resultListeners.contains(listener)) {
-                this.resultListeners.add(listener);
+                final String variant = BindingHelper.getVariantForView((View) listener);
+                if (variant == null || searcher.variant.equals(variant)) {
+                    this.resultListeners.add(listener);
+                    searcher.registerResultListener(listener);
+                    prepareWidget(listener, refinementAttributes);
+                }
             }
-            searcher.registerResultListener(listener);
-            prepareWidget(listener, refinementAttributes);
+
         }
 
-        // Register any AlgoliaErrorListener
+        // Register any AlgoliaErrorListener (unless it has a different variant than searcher)
         final List<AlgoliaErrorListener> errorListeners = LayoutViews.findByClass((ViewGroup) rootView, AlgoliaErrorListener.class);
         for (AlgoliaErrorListener listener : errorListeners) {
             if (!this.errorListeners.contains(listener)) {
-                this.errorListeners.add(listener);
+                final String variant = BindingHelper.getVariantForView((View) listener);
+                if (variant == null || searcher.variant.equals(variant)) {
+                    this.errorListeners.add(listener);
+                }
             }
             searcher.registerErrorListener(listener);
             prepareWidget(listener, refinementAttributes);
         }
 
-        // Register any AlgoliaSearcherListener
+        // Register any AlgoliaSearcherListener (unless it has a different variant than searcher)
         final List<AlgoliaSearcherListener> searcherListeners = LayoutViews.findByClass((ViewGroup) rootView, AlgoliaSearcherListener.class);
         for (AlgoliaSearcherListener listener : searcherListeners) {
-            listener.initWithSearcher(searcher);
-            prepareWidget(listener, refinementAttributes);
+            final String variant = BindingHelper.getVariantForView((View) listener);
+            if (variant == null || searcher.variant.equals(variant)) {
+                listener.initWithSearcher(searcher);
+                prepareWidget(listener, refinementAttributes);
+            }
         }
 
         return refinementAttributes;

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -46,6 +46,7 @@ import java.util.Set;
  * You can either use it with a single widget which will receive incoming results, or with several that will interact together in the same activity.
  */
 public class InstantSearch {
+    //TODO: migrate return void -> return Searcher for chaining methods
     /** Delay before displaying progressbar when the current android API does not support animations. {@literal (API < 14)} */
     @SuppressWarnings("WeakerAccess") public static final int DELAY_PROGRESSBAR_NO_ANIMATIONS = 200;
 

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -392,7 +392,7 @@ public class InstantSearch {
 
         // Register any AlgoliaResultsListener (unless it has a different variant than searcher)
         final List<AlgoliaResultsListener> resultListeners = LayoutViews.findByClass((ViewGroup) rootView, AlgoliaResultsListener.class);
-        if (resultListeners.size() == 0) {
+        if (resultListeners.isEmpty()) {
             throw new IllegalStateException(Errors.LAYOUT_MISSING_RESULT_LISTENER);
         }
         for (AlgoliaResultsListener listener : resultListeners) {
@@ -524,7 +524,7 @@ public class InstantSearch {
 
         // Either the developer uses our SearchBox
         final List<SearchBox> searchBoxes = LayoutViews.findByClass(rootView, SearchBox.class);
-        if (searchBoxes.size() != 0) {
+        if (!searchBoxes.isEmpty()) {
             if (searchBoxes.size() == 1) {
                 facade = new SearchViewFacade(searchBoxes.get(0));
             } else { // We should not find more than one SearchBox
@@ -533,11 +533,11 @@ public class InstantSearch {
         } else { // Or he uses a standard SearchView
             final List<SearchView> searchViews = LayoutViews.findByClass(rootView, SearchView.class);
             final View searchBox = rootView.findViewById(R.id.searchBox);
-            if (searchViews.size() == 0) { // Or he uses a support SearchView
+            if (searchViews.isEmpty()) { // Or he uses a support SearchView
                 final List<android.support.v7.widget.SearchView> supportViews = LayoutViews.findByClass(rootView, android.support.v7.widget.SearchView.class);
-                if (supportViews.size() == 0) { // We should find at least one
+                if (supportViews.isEmpty()) { // We should find at least one
                     Log.e("Algolia|InstantSearch", Errors.LAYOUT_MISSING_SEARCHBOX);
-                } else if (supportViews.size() > 1) { // One of those should have the id @id/searchBox
+                } else if (!supportViews.isEmpty()) { // One of those should have the id @id/searchBox
                     final SearchView labeledSearchView = (SearchView) searchBox;
                     if (labeledSearchView == null) {
                         throw new IllegalStateException(Errors.LAYOUT_TOO_MANY_SEARCHVIEWS);
@@ -547,7 +547,7 @@ public class InstantSearch {
                 } else {
                     facade = new SearchViewFacade(supportViews.get(0));
                 }
-            } else if (searchViews.size() > 1) { // One of those should have the id @id/searchBox
+            } else if (!searchViews.isEmpty()) { // One of those should have the id @id/searchBox
                 final SearchView labeledSearchView = (SearchView) searchBox;
                 if (labeledSearchView == null) {
                     throw new IllegalStateException(Errors.LAYOUT_TOO_MANY_SEARCHVIEWS);

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -375,7 +375,7 @@ public class InstantSearch {
                 this.resultListeners.add(listener);
             }
             searcher.registerResultListener(listener);
-            prepareWidget(rootView, listener, refinementAttributes);
+            prepareWidget(listener, refinementAttributes);
         }
 
         // Register any AlgoliaErrorListener
@@ -385,14 +385,14 @@ public class InstantSearch {
                 this.errorListeners.add(listener);
             }
             searcher.registerErrorListener(listener);
-            prepareWidget(rootView, listener, refinementAttributes);
+            prepareWidget(listener, refinementAttributes);
         }
 
         // Register any AlgoliaSearcherListener
         final List<AlgoliaSearcherListener> searcherListeners = LayoutViews.findByClass((ViewGroup) rootView, AlgoliaSearcherListener.class);
         for (AlgoliaSearcherListener listener : searcherListeners) {
             listener.initWithSearcher(searcher);
-            prepareWidget(rootView, listener, refinementAttributes);
+            prepareWidget(listener, refinementAttributes);
         }
 
         return refinementAttributes;
@@ -405,12 +405,12 @@ public class InstantSearch {
      * @param listener the widget to prepare.
      */
     private void prepareWidget(Object listener) {
-        prepareWidget(null, listener, null);
+        prepareWidget(listener, null);
     }
 
-    private void prepareWidget(@Nullable View rootView, Object listener, @Nullable List<String> refinementAttributes) {
+    private void prepareWidget(Object listener, @Nullable List<String> refinementAttributes) {
         if (listener instanceof View) {
-            prepareWidget(rootView, (View) listener, refinementAttributes);
+            prepareWidget((View) listener, refinementAttributes);
         }
     }
 
@@ -418,11 +418,10 @@ public class InstantSearch {
      * Prepares the widget: adding it to widgets, applying its specific settings
      * and storing its eventual refinement attribute.
      *
-     * @param rootView             the widget's parent for getting an eventual empty view
      * @param widget               the widget to prepare.
      * @param refinementAttributes a List to store the widget's eventual refinement attributes.
      */
-    private void prepareWidget(@Nullable View rootView, View widget, @Nullable List<String> refinementAttributes) {
+    private void prepareWidget(View widget, @Nullable List<String> refinementAttributes) {
         if (!widgets.contains(widget)) { // process once each widget
             widgets.add(widget);
             if (widget instanceof Hits) {

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/InstantSearch.java
@@ -250,7 +250,7 @@ public class InstantSearch {
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
     public void reset() {
         searcher.reset();
-        EventBus.getDefault().post(new ResetEvent());
+        EventBus.getDefault().post(new ResetEvent(searcher));
     }
 
     /**

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -319,7 +319,6 @@ public class Searcher {
      */
     @NonNull
     public Searcher forwardBackendSearchResult(@NonNull JSONObject response) {
-        SearchResults results = new SearchResults(response);
         if (!hasHits(response)) {
             endReached = true;
         } else {

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -206,7 +206,6 @@ public class Searcher {
 
     /**
      * Destroys all Searcher instances.
-     *
      */
     public static void destroyAll() {
         instances.clear();
@@ -616,8 +615,8 @@ public class Searcher {
      * @return a {@link NumericRefinement} describing the current refinement for these parameters, or {@code null} if there is none.
      */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
-    public @Nullable
-    NumericRefinement getNumericRefinement(@NonNull String attribute, int operator) {
+    @Nullable
+    public NumericRefinement getNumericRefinement(@NonNull String attribute, int operator) {
         NumericRefinement.checkOperatorIsValid(operator);
         final SparseArray<NumericRefinement> attributeRefinements = numericRefinements.get(attribute);
         return attributeRefinements == null ? null : attributeRefinements.get(operator);

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -56,7 +56,6 @@ import static com.algolia.instantsearch.events.ResultEvent.REQUEST_UNKNOWN;
 @SuppressWarnings("UnusedReturnValue") // chaining
 public class Searcher {
     private static Map<String, Searcher> instances = new HashMap<>();
-    public static final String VARIANT_DEFAULT = null;
 
     /** The {@link Index} targeted by this Searcher. */
     private Index index;
@@ -565,7 +564,7 @@ public class Searcher {
      * @return the refinements enabled for the given attribute, or {@code null} if there is none.
      */
     @SuppressWarnings({"WeakerAccess", "unused", "SameParameterValue"}) // For library users
-    public @Nullable List<String> getFacetRefinements(@NonNull String attribute) {
+    @Nullable public List<String> getFacetRefinements(@NonNull String attribute) {
         return refinementMap.get(attribute);
     }
 
@@ -706,7 +705,7 @@ public class Searcher {
      * @return the refinement value, or {@code null} if there is none.
      */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
-    public @Nullable Boolean getBooleanFilter(String attribute) {
+    @Nullable public Boolean getBooleanFilter(String attribute) {
         return booleanFilterMap.get(attribute);
     }
 
@@ -882,7 +881,7 @@ public class Searcher {
      * @return this {@link Searcher} for chaining.
      */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
-    public @NonNull Searcher setIndex(@NonNull String indexName) {
+    @NonNull public Searcher setIndex(@NonNull String indexName) {
         index = client.getIndex(indexName);
         query.setPage(0);
         return this;

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -128,7 +128,7 @@ public class Searcher {
     }
 
     /**
-     * Constructs an helper, creating its {@link Searcher#index} and {@link Searcher#client} with the given parameters.
+     * Constructs a Searcher, creating its {@link Searcher#index} and {@link Searcher#client} with the given parameters.
      *
      * @param appId     your Algolia Application ID.
      * @param apiKey    a search-only API Key. (never use API keys that could modify your records! see https://www.algolia.com/doc/guides/security/api-keys)
@@ -155,7 +155,7 @@ public class Searcher {
     }
 
     /**
-     * Constructs the Searcher from an existing {@link Index}.
+     * Constructs a Searcher from an existing {@link Index}.
      *
      * @param index an Index initialized and eventually configured.
      * @return the new instance.

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -389,7 +389,7 @@ public class Searcher {
 
     private Request triggerSearch(CompletionHandler searchHandler) {
         Request searchRequest;
-        if (disjunctiveFacets.size() != 0) {
+        if (!disjunctiveFacets.isEmpty()) {
             searchRequest = index.searchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinementMap, searchHandler);
         } else {
             searchRequest = index.searchAsync(query, searchHandler);
@@ -990,7 +990,7 @@ public class Searcher {
 
     @Override public String toString() {
         String key = null;
-        for (Map.Entry<String, Searcher> entry : instances.entrySet()) {
+        for (Map.Entry<String, Searcher> entry : instances.entrySet()) { //TODO: Refact with BiMap
             if (this.equals(entry.getValue())) {
                 key = entry.getKey();
                 break;

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -258,7 +258,7 @@ public class Searcher {
     public Searcher search(@Nullable final String queryString, @Nullable final Object origin) {
         if (queryString != null) {
             query.setQuery(queryString);
-            EventBus.getDefault().post(new QueryTextChangeEvent(queryString, origin));
+            EventBus.getDefault().post(new QueryTextChangeEvent(queryString, origin == null ? this : origin));
         }
         endReached = false;
         lastRequestPage = 0;

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -63,6 +63,9 @@ public class Searcher {
     private final Client client;
     /** The current state of the search {@link Query}. */
     private Query query;
+    /** The variant identifying this Searcher. */
+    @SuppressWarnings("WeakerAccess") // For library users
+    public final String variant;
 
     /** The {@link AlgoliaResultsListener listeners} that will receive search results. */
     private final List<AlgoliaResultsListener> resultListeners = new ArrayList<>();
@@ -164,7 +167,7 @@ public class Searcher {
         final String key = index.getIndexName();
         Searcher instance = instances.get(key);
         if (instance == null) {
-            instance = new Searcher(index);
+            instance = new Searcher(index, key);
             instances.put(key, instance);
         } else {
             throw new IllegalStateException("There is already a Searcher for index " + key + ", you must specify a variant.");
@@ -175,27 +178,28 @@ public class Searcher {
     /**
      * Constructs the Searcher from an existing {@link Index}, eventually replacing the existing searcher for {@code variant}.
      *
-     * @param variant an identifier to differentiate this Searcher from eventual others using the same index.
+     * @param variant an identifier to differentiate this Searcher from eventual others using the same index. Defaults to the index's name.
      * @param index   an Index initialized and eventually configured.
      * @return the new instance.
      */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
-    public static Searcher create(@NonNull final Index index, String variant) {
+    public static Searcher create(@NonNull final Index index, @NonNull String variant) {
         boolean shouldReplace = false;
         Searcher instance = instances.get(variant);
         if (instance != null) {
             shouldReplace = instance.getIndex() != index;
         }
         if (instance == null || shouldReplace) {
-            instance = new Searcher(index);
+            instance = new Searcher(index, variant);
             instances.put(variant, instance);
         }
         return instance;
     }
 
-    private Searcher(@NonNull final Index index) {
+    private Searcher(@NonNull final Index index, @NonNull String variant) {
         this.index = index;
         this.client = index.getClient();
+        this.variant = variant;
         query = new Query();
         client.addUserAgent(new Client.LibraryVersion("InstantSearch Android", String.valueOf(BuildConfig.VERSION_NAME)));
     }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -186,12 +186,8 @@ public class Searcher {
      */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
     public static Searcher create(@NonNull final Index index, @NonNull String variant) {
-        boolean shouldReplace = false;
         Searcher instance = instances.get(variant);
-        if (instance != null) {
-            shouldReplace = instance.getIndex() != index;
-        }
-        if (instance == null || shouldReplace) {
+        if (instance == null || instance.getIndex() != index) {
             instance = new Searcher(index, variant);
             instances.put(variant, instance);
         }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/model/Errors.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/model/Errors.java
@@ -4,11 +4,8 @@ package com.algolia.instantsearch.model;
 public class Errors {
     public static final String ADAPTER_UNKNOWN_VIEW = "Unrecognized view class (%s): Your view should either use/extend a system view or implement AlgoliaHitView.";
 
-    public static final String BINDING_HIGHLIGHTED_NO_ATTR = "You need an algolia:attribute to use algolia:highlighted.";
-    public static final String BINDING_HIGHLIGHTING_NO_ATTR = "You need an algolia:attribute to use algolia:highlightingColor.";
-    public static final String BINDING_NO_ATTR = "You need an algolia:attribute to use algolia:highlighted and algolia:highlighting.";
-    public static final String BINDING_COLOR_INVALID = "algolia:highlightingColor should be an @android:color or @color resource.";
-    public static final String BINDING_VIEW_NO_ID = "Your View for attribute %s is missing an android:id.";
+    public static final String BINDING_NO_ATTRIBUTE = "Your view lacks an algolia:attribute.";
+    public static final String BINDING_VIEW_NO_ID = "Your View for attribute %s must have an android:id.";
 
     public static final String FILTER_MISSING_ATTRIBUTE = "You must specify an attribute";
 

--- a/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchBoxViewModel.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchBoxViewModel.java
@@ -79,10 +79,11 @@ public class SearchBoxViewModel {
             @Override
             public boolean onQueryTextChange(String newText) {
                 EventBus.getDefault().post(new QueryTextChangeEvent(newText, searchViewFacade.getSearchView()));
+                final String query = searchViewFacade.getQuery().toString();
 
                 for (InstantSearch instantSearch : listeners) {
                     if (newText.length() != 0 || instantSearch.hasSearchOnEmptyString()) {
-                        instantSearch.search(searchViewFacade.getQuery().toString());
+                        instantSearch.search(query);
                     }
                 }
                 return true;

--- a/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchBoxViewModel.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchBoxViewModel.java
@@ -82,7 +82,7 @@ public class SearchBoxViewModel {
                 final String query = searchViewFacade.getQuery().toString();
 
                 for (InstantSearch instantSearch : listeners) {
-                    if (newText.length() != 0 || instantSearch.hasSearchOnEmptyString()) {
+                    if (!newText.isEmpty() || instantSearch.hasSearchOnEmptyString()) {
                         instantSearch.search(query);
                     }
                 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchBoxViewModel.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchBoxViewModel.java
@@ -1,6 +1,7 @@
 package com.algolia.instantsearch.model;
 
 import android.support.annotation.NonNull;
+import android.widget.SearchView;
 
 import com.algolia.instantsearch.events.QueryTextChangeEvent;
 import com.algolia.instantsearch.events.QueryTextSubmitEvent;
@@ -21,12 +22,23 @@ public class SearchBoxViewModel {
     private List<InstantSearch> listeners = new ArrayList<>();
 
     /**
-     * Constructs a {@link SearchBoxViewModel} from an algolia SearchBox.
+     * Constructs a {@link SearchBoxViewModel} from an algolia SearchBox or a support SearchView.
      *
-     * @param searchBox a SearchBox to wrap.
+     * @param searchView a SearchView to wrap.
      */
-    public SearchBoxViewModel(android.support.v7.widget.SearchView searchBox) {
-        this.searchViewFacade = new SearchViewFacade(searchBox);
+    @SuppressWarnings("unused") // For library users
+    public SearchBoxViewModel(@NonNull android.support.v7.widget.SearchView searchView) {
+        this.searchViewFacade = new SearchViewFacade(searchView);
+    }
+
+    /**
+     * Constructs a {@link SearchBoxViewModel} from a SearchView.
+     *
+     * @param searchView a SearchView to wrap.
+     */
+    @SuppressWarnings("unused") // For library users
+    public SearchBoxViewModel(@NonNull SearchView searchView) {
+        this.searchViewFacade = new SearchViewFacade(searchView);
     }
 
     /**

--- a/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchBoxViewModel.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchBoxViewModel.java
@@ -1,0 +1,80 @@
+package com.algolia.instantsearch.model;
+
+import android.support.annotation.NonNull;
+
+import com.algolia.instantsearch.events.QueryTextChangeEvent;
+import com.algolia.instantsearch.events.QueryTextSubmitEvent;
+import com.algolia.instantsearch.helpers.InstantSearch;
+import com.algolia.instantsearch.utils.SearchViewFacade;
+
+import org.greenrobot.eventbus.EventBus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Handles the logic for linking any kind of {@link SearchViewFacade SearchView} to one or several {@link InstantSearch}.
+ */
+public class SearchBoxViewModel {
+
+    private final SearchViewFacade searchViewFacade;
+    private List<InstantSearch> listeners = new ArrayList<>();
+
+    /**
+     * Constructs a {@link SearchBoxViewModel} from an algolia SearchBox.
+     *
+     * @param searchBox a SearchBox to wrap.
+     */
+    public SearchBoxViewModel(android.support.v7.widget.SearchView searchBox) {
+        this.searchViewFacade = new SearchViewFacade(searchBox);
+    }
+
+    /**
+     * Constructs a {@link SearchBoxViewModel} from a SearchViewFacade.
+     *
+     * @param searchViewFacade a SearchViewFacade to wrap.
+     */
+    public SearchBoxViewModel(@NonNull SearchViewFacade searchViewFacade) {
+        this.searchViewFacade = searchViewFacade;
+    }
+
+    public void addListener(InstantSearch instantSearch) {
+        listeners.add(instantSearch);
+
+        // Called with every added InstantSearch, to replace the SearchView's current listener if any
+        setOnQueryTextListener();
+    }
+
+    /**
+     * Gets the SearchViewFacade underlying this SearchBoxViewModel.
+     * @return the {@link SearchBoxViewModel#searchViewFacade}.
+     */
+    public SearchViewFacade getSearchView() {
+        return searchViewFacade;
+    }
+
+    private void setOnQueryTextListener() {
+        searchViewFacade.setOnQueryTextListener(new android.widget.SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                EventBus.getDefault().post(new QueryTextSubmitEvent());
+                // Nothing to do: the search has already been performed by `onQueryTextChange()`.
+                // We do try to close the keyboard, though.
+                searchViewFacade.clearFocus();
+                return true;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                EventBus.getDefault().post(new QueryTextChangeEvent(newText, searchViewFacade.getSearchView()));
+
+                for (InstantSearch instantSearch : listeners) {
+                    if (newText.length() != 0 || instantSearch.hasSearchOnEmptyString()) {
+                        instantSearch.search(searchViewFacade.getQuery().toString());
+                    }
+                }
+                return true;
+            }
+        });
+    }
+}

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
@@ -1,115 +1,56 @@
 package com.algolia.instantsearch.ui.databinding;
 
+import android.annotation.SuppressLint;
 import android.content.res.Resources;
 import android.databinding.BindingAdapter;
 import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
-import android.util.SparseArray;
+import android.support.annotation.Nullable;
+import android.util.Pair;
 import android.view.View;
 
 import com.algolia.instantsearch.model.Errors;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
- * Contains every {@link BindingAdapter} used for binding record attributes to Views.
+ * Contains the {@link BindingAdapter} used for gathering {@link BindingHelper#bindings bound attributes}.
  */
 public class BindingHelper {
-    private static final SparseArray<String> bindings = new SparseArray<>();
+    private static final HashMap<Pair<String, String>, HashMap<Integer, String>> bindings = new HashMap<>();
 
+    /**
+     * @deprecated This should only be used internally by InstantSearch.
+     */
     @SuppressWarnings("unused") // called via Data Binding
     @Deprecated // Should not be used by library users
-    @BindingAdapter({"attribute"})
-    public static void bindAttribute(@NonNull View view, String attribute) {
+    @BindingAdapter(value = {"attribute", "highlighted", "highlightingColor", "index", "variant"}, requireAll = false)
+    public static void bindAttribute(@NonNull View view, @Nullable String attribute,
+                                     @Nullable Boolean highlighted,
+                                     @Nullable @ColorRes Integer color,
+                                     @Nullable String index, @Nullable String variant) {
+        if (attribute == null) {
+            throwBindingError(view, Errors.BINDING_NO_ATTRIBUTE);
+        } else {
+            bindAttribute(view, attribute, index, variant);
+        }
+
+        if ((highlighted != null && highlighted) // either highlighted == true
+                || (color != null && (highlighted == null || !highlighted))) // or color && highlighted != false
+        {
+            highlight(view, attribute, color != null ? color : RenderingHelper.DEFAULT_COLOR);
+        }
+    }
+
+    /**
+     * @deprecated This should only be used internally by InstantSearch.
+     */
+    @Deprecated // Should not be used by library users
+    public static void bindAttribute(@NonNull View view, @NonNull String attribute, @Nullable String index, @Nullable String variant) {
         final int id = view.getId();
-        if (notAlreadyMapped(id)) { // only map when you see a view for the first time.
-            mapAttribute(attribute, id);
-        }
-    }
-
-    @SuppressWarnings({"unused"}) // called via Data Binding
-    @Deprecated // Should not be used by library users
-    @BindingAdapter({"attribute", "highlighted"})
-    public static void bindHighlighted(@NonNull View view, String attribute, Boolean isHighlighted) {
-        // Bind attribute, enable highlight with default color
-        bindAndHighlight(view, attribute, RenderingHelper.DEFAULT_COLOR);
-    }
-
-    @SuppressWarnings({"unused"}) // called via Data Binding
-    @Deprecated // Should not be used by library users
-    @BindingAdapter({"attribute", "highlightingColor"})
-    public static void bindHighlighted(@NonNull View view, String attribute, @NonNull String colorStr) {
-        // Bind attribute, enable highlight with color
-        bindAndHighlight(view, attribute, colorStr);
-    }
-
-    @SuppressWarnings({"unused"}) // called via Data Binding
-    @Deprecated // Should not be used by library users
-    @BindingAdapter({"attribute", "highlighted", "highlightingColor"})
-    public static void bindHighlighted(@NonNull View view, String attribute, Boolean isHighlighted, @NonNull String colorStr) {
-        // Bind attribute, enable highlight with color
-        bindAndHighlight(view, attribute, colorStr);
-    }
-
-    @SuppressWarnings({"unused", "UnusedParameters"}) // called via Data Binding and throws
-    @Deprecated // Should not be used by library users
-    @BindingAdapter({"highlighted"})
-    public static void bindInvalid(@NonNull View view, Boolean isHighlighted) {
-        throwBindingError(view, Errors.BINDING_HIGHLIGHTED_NO_ATTR);
-    }
-
-    @SuppressWarnings({"unused", "UnusedParameters"}) // called via Data Binding and throws
-    @Deprecated // Should not be used by library users
-    @BindingAdapter({"highlightingColor"})
-    public static void bindInvalid(@NonNull View view, @ColorRes int color) {
-        throwBindingError(view, Errors.BINDING_HIGHLIGHTING_NO_ATTR);
-    }
-
-    @SuppressWarnings({"unused", "UnusedParameters"}) // called via Data Binding and throws
-    @Deprecated // Should not be used by library users
-    @BindingAdapter({"highlighted", "highlightingColor"})
-    public static void bindInvalid(@NonNull View view, Boolean isHighlighted, String colorStr) {
-        throwBindingError(view, Errors.BINDING_NO_ATTR);
-    }
-
-    private static boolean notAlreadyMapped(int id) {
-        return bindings.get(id) == null;
-    }
-
-    private static void mapAttribute(String attribute, int viewId) {
-        if (viewId == -1) {
-            throw new IllegalStateException(String.format(Errors.BINDING_VIEW_NO_ID, attribute));
-        }
-        bindings.put(viewId, attribute);
-    }
-
-    private static void throwBindingError(@NonNull View view, String message) {
-        final Resources r = view.getContext().getResources();
-        int id = view.getId();
-        String viewName = r.getResourcePackageName(id) + ":" + r.getResourceTypeName(id) + "/" + r.getResourceEntryName(id);
-        throw new IllegalStateException("Cannot bind " + viewName + ": " + message);
-    }
-
-    private static void bindAndHighlight(@NonNull View view, String attribute, @NonNull String colorStr) {
-        if (notAlreadyMapped(view.getId())) {
-            final String[] split = colorStr.split("/");
-            final String identifierType = split[0];
-            final String colorName = split[1];
-
-            final int colorId;
-            switch (identifierType) {
-                case "@android:color":
-                    colorId = Resources.getSystem().getIdentifier(colorName, "color", "android");
-                    break;
-                case "@color":
-                    colorId = view.getResources().getIdentifier(colorName, "color", view.getContext().getPackageName());
-                    break;
-                default:
-                    throw new IllegalStateException(Errors.BINDING_COLOR_INVALID);
-            }
-
-            bindAttribute(view, attribute);
-            final RenderingHelper renderingHelper = RenderingHelper.getDefault();
-            renderingHelper.addHighlight(attribute);
-            renderingHelper.addColor(attribute, colorId);
+        if (notAlreadyMapped(id, index, variant)) { // only map when you see a view for the first time.
+            mapAttribute(attribute, id, index, variant);
         }
     }
 
@@ -118,7 +59,57 @@ public class BindingHelper {
      *
      * @return a SparseArray mapping each View's id to its attribute name.
      */
-    public static SparseArray<String> getBindings() {
-        return bindings;
+    public static HashMap<Integer, String> getBindings(Pair<String, String> indexVariant) {
+        return bindings.get(indexVariant);
+    }
+
+    /**
+     * Returns the index name and variant associated with the view.
+     *
+     * @param view a View that is associated to an index through databinding.
+     * @return a Pair containing the index name and the variant name (both being {@code null} if unspecified).
+     * @throws IllegalArgumentException if the view is not part of a databinding layout.
+     */
+    public static @NonNull Pair<String, String> getIndexVariantForView(View view) {
+        for (Map.Entry<Pair<String, String>, HashMap<Integer, String>> entry : bindings.entrySet()) {
+            if (entry.getValue().containsKey(view.getId())) {
+                return entry.getKey();
+            }
+        }
+        throw new IllegalArgumentException("View " + getViewName(view) + " was not bound to any data.");
+    }
+
+    private static boolean notAlreadyMapped(int id, @Nullable String index, @Nullable String variant) {
+        final HashMap<Integer, String> indexMap = bindings.get(new Pair<>(index, variant));
+        return indexMap == null || indexMap.get(id) == null;
+    }
+
+    @SuppressLint("UseSparseArrays") // Using HashMap for O(1) containsKey in getIndexVariantForView
+    private static void mapAttribute(String attribute, int viewId, @Nullable String index, @Nullable String variant) {
+        if (viewId == -1) {
+            throw new IllegalStateException(String.format(Errors.BINDING_VIEW_NO_ID, attribute));
+        }
+        final Pair<String, String> key = new Pair<>(index, variant);
+        HashMap<Integer, String> indexMap = bindings.get(key);
+        if (indexMap == null) {
+            indexMap = new HashMap<>();
+            bindings.put(key, indexMap);
+        }
+        indexMap.put(viewId, attribute);
+    }
+
+    private static void throwBindingError(@NonNull View view, String message) {
+        String viewName = getViewName(view);
+        throw new IllegalStateException("Cannot bind " + viewName + ": " + message);
+    }
+
+    @NonNull private static String getViewName(@NonNull View view) {
+        final Resources r = view.getContext().getResources();
+        int id = view.getId();
+        return r.getResourcePackageName(id) + ":" + r.getResourceTypeName(id) + "/" + r.getResourceEntryName(id);
+    }
+
+    private static void highlight(@NonNull View view, String attribute, @ColorRes int color) {
+        RenderingHelper.getDefault().addHighlight(view, attribute, color);
     }
 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
@@ -6,6 +6,7 @@ import android.databinding.BindingAdapter;
 import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.SparseArray;
 import android.view.View;
 
 import com.algolia.instantsearch.model.Errors;
@@ -18,6 +19,8 @@ import java.util.Map;
  */
 public class BindingHelper {
     private static final HashMap<String, HashMap<Integer, String>> bindings = new HashMap<>();
+    private static final SparseArray<String> prefixes = new SparseArray<>();
+    private static final SparseArray<String> suffixes = new SparseArray<>();
 
     /**
      * @deprecated This should only be used internally by InstantSearch.
@@ -40,6 +43,13 @@ public class BindingHelper {
                 || (color != null && (highlighted == null || !highlighted))) // or color && highlighted != false
         {
             highlight(view, attribute, color != null ? color : RenderingHelper.DEFAULT_COLOR);
+        }
+
+        if (prefix != null) {
+            prefixes.put(view.getId(), prefix);
+        }
+        if (suffix != null) {
+            suffixes.put(view.getId(), suffix);
         }
     }
 
@@ -110,5 +120,27 @@ public class BindingHelper {
 
     private static void highlight(@NonNull View view, String attribute, @ColorRes int color) {
         RenderingHelper.getDefault().addHighlight(view, attribute, color);
+    }
+
+    /**
+     * Gets the full version of an attribute, with its eventual prefix and suffix.
+     *
+     * @param view         the view mapped to this attribute.
+     * @param rawAttribute the raw value of the attribute.
+     * @return the attribute value, prefixed and suffixed if any was specified on the view.
+     */
+    public static String getFullAttribute(View view, String rawAttribute) {
+        String attribute = "";
+        final int id = view.getId();
+        final String prefix = prefixes.get(id);
+        final String suffix = suffixes.get(id);
+        if (prefix != null) {
+            attribute = prefix;
+        }
+        attribute += rawAttribute;
+        if (suffix != null) {
+            attribute = prefix;
+        }
+        return attribute;
     }
 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
@@ -80,7 +80,7 @@ public class BindingHelper {
      * @return the variant name or {@code null} if unspecified.
      * @throws IllegalArgumentException if the view is not part of a databinding layout.
      */
-    public static @NonNull String getVariantForView(View view) {
+    public static @Nullable String getVariantForView(View view) {
         for (Map.Entry<String, HashMap<Integer, String>> entry : bindings.entrySet()) {
             if (entry.getValue().containsKey(view.getId())) {
                 return entry.getKey();

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
@@ -6,7 +6,6 @@ import android.databinding.BindingAdapter;
 import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Pair;
 import android.view.View;
 
 import com.algolia.instantsearch.model.Errors;
@@ -18,22 +17,22 @@ import java.util.Map;
  * Contains the {@link BindingAdapter} used for gathering {@link BindingHelper#bindings bound attributes}.
  */
 public class BindingHelper {
-    private static final HashMap<Pair<String, String>, HashMap<Integer, String>> bindings = new HashMap<>();
+    private static final HashMap<String, HashMap<Integer, String>> bindings = new HashMap<>();
 
     /**
      * @deprecated This should only be used internally by InstantSearch.
      */
     @SuppressWarnings("unused") // called via Data Binding
     @Deprecated // Should not be used by library users
-    @BindingAdapter(value = {"attribute", "highlighted", "highlightingColor", "index", "variant"}, requireAll = false)
+    @BindingAdapter(value = {"attribute", "highlighted", "highlightingColor", "variant"}, requireAll = false)
     public static void bindAttribute(@NonNull View view, @Nullable String attribute,
                                      @Nullable Boolean highlighted,
                                      @Nullable @ColorRes Integer color,
-                                     @Nullable String index, @Nullable String variant) {
+                                     @Nullable String variant) {
         if (attribute == null) {
             throwBindingError(view, Errors.BINDING_NO_ATTRIBUTE);
         } else {
-            bindAttribute(view, attribute, index, variant);
+            bindAttribute(view, attribute, variant);
         }
 
         if ((highlighted != null && highlighted) // either highlighted == true
@@ -47,10 +46,10 @@ public class BindingHelper {
      * @deprecated This should only be used internally by InstantSearch.
      */
     @Deprecated // Should not be used by library users
-    public static void bindAttribute(@NonNull View view, @NonNull String attribute, @Nullable String index, @Nullable String variant) {
+    public static void bindAttribute(@NonNull View view, @NonNull String attribute, @Nullable String variant) {
         final int id = view.getId();
-        if (notAlreadyMapped(id, index, variant)) { // only map when you see a view for the first time.
-            mapAttribute(attribute, id, index, variant);
+        if (notAlreadyMapped(id, variant)) { // only map when you see a view for the first time.
+            mapAttribute(attribute, id, variant);
         }
     }
 
@@ -59,19 +58,19 @@ public class BindingHelper {
      *
      * @return a SparseArray mapping each View's id to its attribute name.
      */
-    public static HashMap<Integer, String> getBindings(Pair<String, String> indexVariant) {
+    public static HashMap<Integer, String> getBindings(String indexVariant) {
         return bindings.get(indexVariant);
     }
 
     /**
-     * Returns the index name and variant associated with the view.
+     * Returns the variant associated with the view.
      *
      * @param view a View that is associated to an index through databinding.
-     * @return a Pair containing the index name and the variant name (both being {@code null} if unspecified).
+     * @return the variant name or {@code null} if unspecified.
      * @throws IllegalArgumentException if the view is not part of a databinding layout.
      */
-    public static @NonNull Pair<String, String> getIndexVariantForView(View view) {
-        for (Map.Entry<Pair<String, String>, HashMap<Integer, String>> entry : bindings.entrySet()) {
+    public static @NonNull String getVariantForView(View view) {
+        for (Map.Entry<String, HashMap<Integer, String>> entry : bindings.entrySet()) {
             if (entry.getValue().containsKey(view.getId())) {
                 return entry.getKey();
             }
@@ -79,17 +78,17 @@ public class BindingHelper {
         throw new IllegalArgumentException("View " + getViewName(view) + " was not bound to any data.");
     }
 
-    private static boolean notAlreadyMapped(int id, @Nullable String index, @Nullable String variant) {
-        final HashMap<Integer, String> indexMap = bindings.get(new Pair<>(index, variant));
+    private static boolean notAlreadyMapped(int id, @Nullable String variant) {
+        final HashMap<Integer, String> indexMap = bindings.get(variant);
         return indexMap == null || indexMap.get(id) == null;
     }
 
-    @SuppressLint("UseSparseArrays") // Using HashMap for O(1) containsKey in getIndexVariantForView
-    private static void mapAttribute(String attribute, int viewId, @Nullable String index, @Nullable String variant) {
+    @SuppressLint("UseSparseArrays") // Using HashMap for O(1) containsKey in getVariantForView
+    private static void mapAttribute(String attribute, int viewId, @Nullable String variant) {
         if (viewId == -1) {
             throw new IllegalStateException(String.format(Errors.BINDING_VIEW_NO_ID, attribute));
         }
-        final Pair<String, String> key = new Pair<>(index, variant);
+        final String key = variant;
         HashMap<Integer, String> indexMap = bindings.get(key);
         if (indexMap == null) {
             indexMap = new HashMap<>();

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
@@ -24,11 +24,12 @@ public class BindingHelper {
      */
     @SuppressWarnings("unused") // called via Data Binding
     @Deprecated // Should not be used by library users
-    @BindingAdapter(value = {"attribute", "highlighted", "highlightingColor", "variant"}, requireAll = false)
+    @BindingAdapter(value = {"attribute", "highlighted", "highlightingColor", "variant", "prefix", "suffix"}, requireAll = false)
     public static void bindAttribute(@NonNull View view, @Nullable String attribute,
                                      @Nullable Boolean highlighted,
                                      @Nullable @ColorRes Integer color,
-                                     @Nullable String variant) {
+                                     @Nullable String variant,
+                                     @Nullable String prefix, @Nullable String suffix) {
         if (attribute == null) {
             throwBindingError(view, Errors.BINDING_NO_ATTRIBUTE);
         } else {
@@ -88,11 +89,10 @@ public class BindingHelper {
         if (viewId == -1) {
             throw new IllegalStateException(String.format(Errors.BINDING_VIEW_NO_ID, attribute));
         }
-        final String key = variant;
-        HashMap<Integer, String> indexMap = bindings.get(key);
+        HashMap<Integer, String> indexMap = bindings.get(variant);
         if (indexMap == null) {
             indexMap = new HashMap<>();
-            bindings.put(key, indexMap);
+            bindings.put(variant, indexMap);
         }
         indexMap.put(viewId, attribute);
     }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.databinding.BindingAdapter;
-import android.support.annotation.ColorRes;
+import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
@@ -34,7 +34,7 @@ public class BindingHelper {
     @BindingAdapter(value = {"attribute", "highlighted", "highlightingColor", "variant", "prefix", "suffix"}, requireAll = false)
     public static void bindAttribute(@NonNull View view, @Nullable String attribute,
                                      @Nullable Boolean highlighted,
-                                     @Nullable @ColorRes Integer color,
+                                     @Nullable @ColorInt Integer color,
                                      @Nullable String variant,
                                      @Nullable String prefix, @Nullable String suffix) {
         if (attribute == null) {
@@ -133,7 +133,7 @@ public class BindingHelper {
                 return entry.getKey();
             }
         }
-        throw new IllegalArgumentException("View " + getViewName(view) + " was not bound to any data.");
+        return null;
     }
 
     private static boolean notAlreadyMapped(int id, @Nullable String variant) {
@@ -165,7 +165,7 @@ public class BindingHelper {
         return r.getResourcePackageName(id) + ":" + r.getResourceTypeName(id) + "/" + r.getResourceEntryName(id);
     }
 
-    private static void highlight(@NonNull View view, String attribute, @ColorRes int color) {
+    private static void highlight(@NonNull View view, String attribute, @ColorInt int color) {
         RenderingHelper.getDefault().addHighlight(view, attribute, color);
     }
 

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/BindingHelper.java
@@ -127,7 +127,7 @@ public class BindingHelper {
      * @return the variant name or {@code null} if unspecified.
      * @throws IllegalArgumentException if the view is not part of a databinding layout.
      */
-    public static @Nullable String getVariantForView(View view) {
+    @Nullable public static String getVariantForView(@NonNull View view) {
         for (Map.Entry<String, HashMap<Integer, String>> entry : bindings.entrySet()) {
             if (entry.getValue().containsKey(view.getId())) {
                 return entry.getKey();

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/RenderingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/RenderingHelper.java
@@ -2,6 +2,10 @@ package com.algolia.instantsearch.ui.databinding;
 
 import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
+import android.util.Pair;
+import android.view.View;
+
+import com.algolia.instantsearch.R;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -9,21 +13,19 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Contains mappings between an attribute to highlight and its appropriate highlighting color.
+ * Contains mappings between a view+attribute to highlight and its appropriate highlighting color.
  */
 @SuppressWarnings("UnusedReturnValue")
 public class RenderingHelper {
-    final static String DEFAULT_COLOR = "@color/colorHighlighting";
+    final static int DEFAULT_COLOR = R.color.colorHighlighting;
 
     /** The default RenderingHelper, highlighting with the {@link RenderingHelper#DEFAULT_COLOR default color}. */
     private static RenderingHelper defaultRenderingHelper;
 
-    /** The Set of attributes to highlight. */
-    @NonNull
-    private final Set<String> highlightedAttributes;
-    /** A Map associating attributes with their respective highlighting {@link ColorRes color}. */
-    @NonNull
-    private final Map<String, Integer> attributeColors;
+    /** The Set of view/attribute pairs to highlight. */
+    @NonNull private final Set<Pair<View, String>> highlightedAttributes;
+    /** A Map associating view/attribute pairs with their respective highlighting {@link ColorRes color}. */
+    @NonNull private final Map<Pair<View, String>, Integer> attributeColors;
 
     /**
      * Gets the {@link RenderingHelper#defaultRenderingHelper default RenderingHelper}.
@@ -43,47 +45,41 @@ public class RenderingHelper {
     }
 
     /**
-     * Gets the highlighting color for a given attribute.
+     * Gets the highlighting color for a given view/attribute pair.
      *
+     * @param view      the view using this attribute.
      * @param attribute the attribute's name.
-     * @return the {@link ColorRes} associated with this attribute, or 0 if there is none.
+     * @return the {@link ColorRes} associated with this view/attribute pair, or 0 if there is none.
      */
-    public @ColorRes Integer getHighlightColor(String attribute) {
+    public @ColorRes Integer getHighlightColor(View view, String attribute) {
         try {
-            return attributeColors.get(attribute);
+            return attributeColors.get(new Pair<>(view, attribute));
         } catch (NullPointerException e) {
             return 0;
         }
     }
 
     /**
-     * Checks if an attribute should be highlighted.
+     * Checks if an attribute should be highlighted in a view.
      *
+     * @param view      the view using this attribute.
      * @param attribute the attribute's name.
      * @return {@code true} if the attribute was marked for highlighting.
      */
-    public boolean shouldHighlight(String attribute) {
-        return highlightedAttributes.contains(attribute);
+    public boolean shouldHighlight(View view, String attribute) {
+        return highlightedAttributes.contains(new Pair<>(view, attribute));
     }
 
     /**
-     * Sets a color for this attribute's highlighting.
+     * Enables highlighting for this view/attribute pair.
      *
      * @param attribute the attribute to color.
      * @param colorId   a {@link ColorRes} to associate with this attribute.
      * @return the previous color associated with this attribute or {@code null} if there was none.
      */
-    Integer addColor(String attribute, @ColorRes int colorId) {
-        return attributeColors.put(attribute, colorId);
-    }
-
-    /**
-     * Enables highlighting for this attribute.
-     *
-     * @param attribute the attribute to color.
-     * @return {@code true} if the attribute was not already highlighted, {@code false} otherwise.
-     */
-    boolean addHighlight(String attribute) {
-        return highlightedAttributes.add(attribute);
+    Integer addHighlight(View view, String attribute, @ColorRes int colorId) {
+        final Pair<View, String> pair = new Pair<>(view, attribute);
+        highlightedAttributes.add(pair);
+        return attributeColors.put(pair, colorId);
     }
 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/RenderingHelper.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/databinding/RenderingHelper.java
@@ -1,5 +1,6 @@
 package com.algolia.instantsearch.ui.databinding;
 
+import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
 import android.util.Pair;
@@ -17,14 +18,14 @@ import java.util.Set;
  */
 @SuppressWarnings("UnusedReturnValue")
 public class RenderingHelper {
-    final static int DEFAULT_COLOR = R.color.colorHighlighting;
+    @ColorRes final static int DEFAULT_COLOR = R.color.colorHighlighting;
 
     /** The default RenderingHelper, highlighting with the {@link RenderingHelper#DEFAULT_COLOR default color}. */
     private static RenderingHelper defaultRenderingHelper;
 
     /** The Set of view/attribute pairs to highlight. */
     @NonNull private final Set<Pair<View, String>> highlightedAttributes;
-    /** A Map associating view/attribute pairs with their respective highlighting {@link ColorRes color}. */
+    /** A Map associating view/attribute pairs with their respective highlighting {@link ColorInt color}. */
     @NonNull private final Map<Pair<View, String>, Integer> attributeColors;
 
     /**
@@ -49,9 +50,9 @@ public class RenderingHelper {
      *
      * @param view      the view using this attribute.
      * @param attribute the attribute's name.
-     * @return the {@link ColorRes} associated with this view/attribute pair, or 0 if there is none.
+     * @return the {@link ColorInt} associated with this view/attribute pair, or 0 if there is none.
      */
-    public @ColorRes Integer getHighlightColor(View view, String attribute) {
+    public @ColorInt Integer getHighlightColor(View view, String attribute) {
         try {
             return attributeColors.get(new Pair<>(view, attribute));
         } catch (NullPointerException e) {
@@ -74,10 +75,10 @@ public class RenderingHelper {
      * Enables highlighting for this view/attribute pair.
      *
      * @param attribute the attribute to color.
-     * @param colorId   a {@link ColorRes} to associate with this attribute.
+     * @param colorId   a {@link ColorInt} to associate with this attribute.
      * @return the previous color associated with this attribute or {@code null} if there was none.
      */
-    Integer addHighlight(View view, String attribute, @ColorRes int colorId) {
+    Integer addHighlight(View view, String attribute, @ColorInt int colorId) {
         final Pair<View, String> pair = new Pair<>(view, attribute);
         highlightedAttributes.add(pair);
         return attributeColors.put(pair, colorId);

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -466,6 +466,10 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
             for (Map.Entry<View, String> entry : holder.viewMap.entrySet()) {
                 final View view = entry.getKey();
                 final String attributeName = entry.getValue();
+                if (attributeName == null) {
+                    Log.d("Hits", "View " + view.toString() + " is bound to null attribute, skipping");
+                    continue;
+                }
                 final String attributeValue = BindingHelper.getFullAttribute(view, JSONUtils.getStringFromJSONPath(hit, attributeName));
                 if (view instanceof AlgoliaHitView) {
                     ((AlgoliaHitView) view).onUpdateView(hit);
@@ -577,7 +581,9 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
                 // Store every annotated view for indexVariant with its attribute name
                 final HashMap<Integer, String> attributes = BindingHelper.getBindings(indexVariant);
                 for (Map.Entry<Integer, String> entry : attributes.entrySet()) {
-                    viewMap.put(itemView.findViewById(entry.getKey()), entry.getValue());
+                    if (entry.getValue() != null) { // attribute can be null e.g. if view is a Hits
+                        viewMap.put(itemView.findViewById(entry.getKey()), entry.getValue());
+                    }
                 }
             }
         }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -530,7 +530,7 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
             Spannable attributeText;
             if (RenderingHelper.getDefault().shouldHighlight(view, attribute)) {
                 final int highlightColor = RenderingHelper.getDefault().getHighlightColor(view, attribute);
-                attributeText = Highlighter.getDefault().renderHighlightColor(hit, attribute, highlightColor, view.getContext());
+                attributeText = Highlighter.getDefault().renderHighlightColor(hit, attribute, highlightColor);
             } else {
                 attributeText = attributeValue != null ? new SpannableString(attributeValue) : null;
             }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -132,6 +132,7 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
                 }
             }
 
+            BindingHelper.setVariantForView(this, attrs);
         } finally {
             styledAttributes.recycle();
         }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -17,7 +17,6 @@ import android.text.Spannable;
 import android.text.SpannableString;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.util.Pair;
 import android.util.SparseArray;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -553,12 +552,12 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
         class ViewHolder extends RecyclerView.ViewHolder {
             private final Map<View, String> viewMap = new HashMap<>();
             // needed to differentiate initial key value from Pair{null,null} which is legitimate
-            private final String defaultValue = "ADefaultValueForHitsIndexVariant";
+            private final String defaultValue = "ADefaultValueForHitsVariant";
 
             ViewHolder(@NonNull View itemView) {
                 super(itemView);
 
-                Pair<String, String> indexVariant = new Pair<>(defaultValue, defaultValue);
+                String indexVariant = defaultValue;
 
                 // Get the index and variant for this layout
                 final List<View> views = LayoutViews.findAny((ViewGroup) itemView);
@@ -566,9 +565,9 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
                     if (view instanceof AlgoliaHitView) {
                         continue;
                     }
-                    Pair<String, String> viewIndexVariant = BindingHelper.getIndexVariantForView(view);
-                    if (!defaultValue.equals(indexVariant.first) && !viewIndexVariant.equals(indexVariant)) {
-                        throw new IllegalStateException("Hits found two conflicting indices/variants:" + indexVariant.toString() + " / " + viewIndexVariant.toString());
+                    String viewIndexVariant = BindingHelper.getVariantForView(view);
+                    if (!defaultValue.equals(indexVariant) && !viewIndexVariant.equals(indexVariant)) {
+                        throw new IllegalStateException("Hits found two conflicting indices/variants:" + indexVariant + " / " + viewIndexVariant);
                     }
                     indexVariant = viewIndexVariant;
                 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -77,14 +77,14 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
     private final @NonNull Integer hitsPerPage;
     private final int layoutId;
 
-    private @NonNull HitsAdapter adapter;
-    private @NonNull LayoutManager layoutManager;
-    private @NonNull Searcher searcher;
-    private @NonNull InputMethodManager imeManager;
+    @NonNull private HitsAdapter adapter;
+    @NonNull private LayoutManager layoutManager;
+    @NonNull private Searcher searcher;
+    @NonNull private InputMethodManager imeManager;
 
-    private @Nullable final InfiniteScrollListener infiniteScrollListener;
-    private @Nullable OnScrollListener keyboardListener;
-    private @Nullable View emptyView;
+    @Nullable private final InfiniteScrollListener infiniteScrollListener;
+    @Nullable private OnScrollListener keyboardListener;
+    @Nullable private View emptyView;
 
     /**
      * Constructs a new Hits with the given context's theme and the supplied attribute set.

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -566,8 +566,9 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
                         continue;
                     }
                     String viewIndexVariant = BindingHelper.getVariantForView(view);
-                    if (!defaultValue.equals(indexVariant) && !viewIndexVariant.equals(indexVariant)) {
-                        throw new IllegalStateException("Hits found two conflicting indices/variants:" + indexVariant + " / " + viewIndexVariant);
+                    final boolean isDifferentVariant = !(viewIndexVariant == null ? indexVariant == null : viewIndexVariant.equals(indexVariant));
+                    if (!defaultValue.equals(indexVariant) && isDifferentVariant) {
+                        throw new IllegalStateException("Hits found two conflicting variants within its views: " + indexVariant + " / " + viewIndexVariant + ".");
                     }
                     indexVariant = viewIndexVariant;
                 }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -32,7 +32,6 @@ import android.widget.TextView;
 import com.algolia.instantsearch.R;
 import com.algolia.instantsearch.events.ResetEvent;
 import com.algolia.instantsearch.helpers.Highlighter;
-import com.algolia.instantsearch.helpers.InstantSearch;
 import com.algolia.instantsearch.helpers.Searcher;
 import com.algolia.instantsearch.model.AlgoliaErrorListener;
 import com.algolia.instantsearch.model.AlgoliaResultsListener;
@@ -443,7 +442,7 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
         @Override
         public ViewHolder onCreateViewHolder(@NonNull final ViewGroup parent, int viewType) {
             ViewDataBinding binding = DataBindingUtil.inflate(
-                    LayoutInflater.from(parent.getContext()), InstantSearch.getItemLayoutId(), parent, false);
+                    LayoutInflater.from(parent.getContext()), layoutId, parent, false);
             binding.executePendingBindings();
             return new ViewHolder(binding.getRoot());
         }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -571,8 +571,9 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
                         continue;
                     }
                     String viewIndexVariant = BindingHelper.getVariantForView(view);
-                    final boolean isDifferentVariant = !(viewIndexVariant == null ? indexVariant == null : viewIndexVariant.equals(indexVariant));
-                    if (!defaultValue.equals(indexVariant) && isDifferentVariant) {
+                    final boolean isSameVariant = viewIndexVariant == null ?
+                            indexVariant == null : viewIndexVariant.equals(indexVariant);
+                    if (!defaultValue.equals(indexVariant) && !isSameVariant) {
                         throw new IllegalStateException("Hits found two conflicting variants within its views: " + indexVariant + " / " + viewIndexVariant + ".");
                     }
                     indexVariant = viewIndexVariant;

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -74,7 +74,7 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
     /** The minimum number of items remaining below the fold before loading more. */
     private final int remainingItemsBeforeLoading;
 
-    private final @NonNull Integer hitsPerPage;
+    @NonNull private final Integer hitsPerPage;
     private final int layoutId;
 
     @NonNull private HitsAdapter adapter;

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/Hits.java
@@ -465,7 +465,7 @@ public class Hits extends RecyclerView implements AlgoliaResultsListener, Algoli
             for (Map.Entry<View, String> entry : holder.viewMap.entrySet()) {
                 final View view = entry.getKey();
                 final String attributeName = entry.getValue();
-                final String attributeValue = JSONUtils.getStringFromJSONPath(hit, attributeName);
+                final String attributeValue = BindingHelper.getFullAttribute(view, JSONUtils.getStringFromJSONPath(hit, attributeName));
                 if (view instanceof AlgoliaHitView) {
                     ((AlgoliaHitView) view).onUpdateView(hit);
                 } else if (view instanceof EditText) {

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/RefinementList.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/RefinementList.java
@@ -229,38 +229,6 @@ public class RefinementList extends ListView implements AlgoliaFilter, AlgoliaRe
         }
     }
 
-    /**
-     * Replaces the default sortComparator by a custom one respecting the {@link Comparator} interface.
-     *
-     * @param sortComparator a new Comparator to use for sorting facetValues.
-     * @see #DEFAULT_SORT
-     */
-    @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
-    public void setSortComparator(@NonNull Comparator<? super FacetValue> sortComparator) {
-        this.sortComparator = sortComparator;
-    }
-
-    /**
-     * Gets the attribute that this RefinementList refines on.
-     *
-     * @return the RefinementList's {@link RefinementList#attribute}.
-     */
-    @Override
-    @NonNull public String getAttribute() {
-        return attribute;
-    }
-
-    /**
-     * Gets the operation used by this RefinementList for filtering.
-     *
-     * @return the RefinementList's {@link RefinementList#operation}.
-     * @see #OPERATION_AND
-     * @see #OPERATION_OR
-     */
-    public int getOperation() {
-        return operation;
-    }
-
     @Nullable
     static ArrayList<String> parseSortOrder(@Nullable String attribute) {
         if (attribute == null) {

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/RefinementList.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/RefinementList.java
@@ -192,7 +192,7 @@ public class RefinementList extends ListView implements AlgoliaFilter, AlgoliaRe
         List<FacetValue> refinementFacets = facets.get(attribute);
 
         // If we have new facetValues we should use them, and else set count=0 to old ones
-        if (refinementFacets != null && refinementFacets.size() > 0) {
+        if (refinementFacets != null && !refinementFacets.isEmpty()) {
             adapter.clear(false);
             adapter.addAll(refinementFacets);
             adapter.sort(sortComparator);

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/RefinementList.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/RefinementList.java
@@ -233,7 +233,7 @@ public class RefinementList extends ListView implements AlgoliaFilter, AlgoliaRe
      * @return the RefinementList's {@link RefinementList#attribute}.
      */
     @Override
-    public @NonNull String getAttribute() {
+    @NonNull public String getAttribute() {
         return attribute;
     }
 

--- a/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/SearchBox.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/ui/views/SearchBox.java
@@ -10,6 +10,7 @@ import android.view.inputmethod.EditorInfo;
 
 import com.algolia.instantsearch.R;
 import com.algolia.instantsearch.events.QueryTextChangeEvent;
+import com.algolia.instantsearch.ui.databinding.BindingHelper;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -68,6 +69,7 @@ public class SearchBox extends SearchView {
             } finally {
                 styledAttributes.recycle();
             }
+            BindingHelper.setVariantForView(this, attrs);
         }
     }
 

--- a/instantsearch/src/main/java/com/algolia/instantsearch/utils/LayoutViews.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/utils/LayoutViews.java
@@ -24,9 +24,10 @@ final public class LayoutViews {
 
     /**
      * Gets a List of Views matching a given class.
-     * @param rootView the root View to traverse.
+     *
+     * @param rootView  the root View to traverse.
      * @param classType the class to find.
-     * @param <T> the class to find.
+     * @param <T>       the class to find.
      * @return a List of every matching View encountered.
      */
     @NonNull public static <T> List<T> findByClass(@NonNull View rootView, Class<T> classType) {
@@ -36,9 +37,10 @@ final public class LayoutViews {
 
     /**
      * Gets a List of Views matching a given class.
-     * @param root the root ViewGroup to traverse.
+     *
+     * @param root      the root ViewGroup to traverse.
      * @param classType the class to find.
-     * @param <T> the class to find.
+     * @param <T>       the class to find.
      * @return a List of every matching View encountered.
      */
     @NonNull public static <T> List<T> findByClass(@NonNull ViewGroup root, Class<T> classType) {
@@ -46,6 +48,19 @@ final public class LayoutViews {
         LayoutTraverser.build(finderByClass)
                 .traverse(root);
         return finderByClass.getViews();
+    }
+
+    /**
+     * Gets a List of Views from a ViewGroup.
+     *
+     * @param root      the root ViewGroup to traverse.
+     * @return a List of every View encountered.
+     */
+    @NonNull public static List<View> findAny(@NonNull ViewGroup root) {
+        FinderAny finder = new FinderAny();
+        LayoutTraverser.build(finder)
+                .traverse(root);
+        return finder.getViews();
     }
 
     private static class FinderByTag implements LayoutTraverser.Processor {
@@ -89,6 +104,25 @@ final public class LayoutViews {
         }
 
         @NonNull public List<T> getViews() {
+            return views;
+        }
+    }
+
+    private static class FinderAny implements LayoutTraverser.Processor {
+        @NonNull
+        private final List<View> views;
+
+        private FinderAny() {
+            views = new ArrayList<>();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public void process(@NonNull View view) {
+            views.add(view);
+        }
+
+        @NonNull public List<View> getViews() {
             return views;
         }
     }

--- a/instantsearch/src/main/res/values/attrs.xml
+++ b/instantsearch/src/main/res/values/attrs.xml
@@ -2,6 +2,7 @@
 <resources>
     <declare-styleable name="View">
         <attr name="attribute" format="string"/>
+        <attr name="variant" format="string"/>
         <attr name="highlighted" format="boolean"/>
         <attr name="highlightColor" format="color"/>
     </declare-styleable>

--- a/instantsearch/src/test/java/com/algolia/instantsearch/helpers/SearcherTest.java
+++ b/instantsearch/src/test/java/com/algolia/instantsearch/helpers/SearcherTest.java
@@ -34,11 +34,23 @@ public class SearcherTest extends InstantSearchTest {
         Searcher.destroyAll();
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void instantiatesDuplicateNoVariantThrows() {
+        final String indexName = "asd";
+        final Client client = initClient();
+        Searcher.create(client.getIndex(indexName));
+        Searcher.create(client.getIndex(indexName));
+    }
+
     @Test public void instantiatesAccordingToVariant() {
         final String indexName = "asd";
         final Client client = initClient();
-        Searcher searcher = Searcher.create(client.getIndex(indexName));
-        Searcher searcher2 = Searcher.create(client.getIndex(indexName + "_foo"));
+        Searcher searcher = Searcher.create(client.getIndex(indexName), "foo");
+        Searcher searcher2 = Searcher.create(client.getIndex(indexName), "foo");
+        Assert.assertSame("Two searchers with same indexNames and variants should be the same instance.", searcher, searcher2);
+
+        searcher = Searcher.create(client.getIndex(indexName));
+        searcher2 = Searcher.create(client.getIndex(indexName + "_foo"));
         Assert.assertNotSame("Two searchers with different indexNames and no variants should be different instance.", searcher, searcher2);
 
         searcher = Searcher.create(client.getIndex(indexName), "variant");

--- a/instantsearch/src/test/java/com/algolia/instantsearch/helpers/SearcherTest.java
+++ b/instantsearch/src/test/java/com/algolia/instantsearch/helpers/SearcherTest.java
@@ -18,10 +18,38 @@ import org.junit.Test;
 import java.util.Locale;
 
 public class SearcherTest extends InstantSearchTest {
+    @NonNull private Client initClient() {
+        return new Client(Helpers.app_id, Helpers.api_key);
+    }
+
     @NonNull
     private Searcher initSearcher() {
-        final Client client = new Client(Helpers.app_id, Helpers.api_key);
+        final Client client = initClient();
         return Searcher.create(client.getIndex(Helpers.safeIndexName("test")));
+    }
+
+    @Test public void instantiatesAccordingToIndexAndVariant() {
+        final String indexName = "asd";
+        final Client client = initClient();
+        Searcher searcher = Searcher.create(client.getIndex(indexName));
+        Searcher searcher2 = Searcher.create(client.getIndex(indexName));
+        Assert.assertSame("Two searchers with the same indexName and no variants should be the same instance.", searcher, searcher2);
+
+        searcher = Searcher.create(client.getIndex(indexName));
+        searcher2 = Searcher.create(client.getIndex(indexName + "_foo"));
+        Assert.assertNotSame("Two searchers with different indexNames and no variants should be different instance.", searcher, searcher2);
+
+        searcher = Searcher.create(client.getIndex(indexName), "variant");
+        searcher2 = Searcher.create(client.getIndex("bar"), "variant");
+        Assert.assertNotSame("Two searchers with different indexNames and same variants should be different instance.", searcher, searcher2);
+
+        searcher = Searcher.create(client.getIndex(indexName), "variant1");
+        searcher2 = Searcher.create(client.getIndex(indexName), "variant2");
+        Assert.assertNotSame("Two searchers with the same indexName but different variants should be different instances.", searcher, searcher2);
+
+        searcher = Searcher.create(client.getIndex(indexName), "variant1");
+        searcher2 = Searcher.create(client.getIndex("bar"), "variant2");
+        Assert.assertNotSame("Two searchers with different indexNames and variants should be different instances.", searcher, searcher2);
     }
 
     @Test


### PR DESCRIPTION
Provides multi index capabilities.
- [x] Instantiating InstantSearch with an activity using several Fragments
- [x] Creating several searchers
- [x] Filtering DataBinding's bindings based on the widget group
- [x] Discriminating events depending on the Searcher that triggered them
- [x] Registering all widgets in an Activity, discriminating between variants
- [x] Having a SearchView call several searchers, not only the last one registered

Usage as seen in [movies example app](https://github.com/algolia/instantsearch-android-examples/tree/feat/moviesDemo#movies-application):
```java
// Instantiate your Searchers
searcherMovies = Searcher.create(ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX_MOVIES);
searcherActors = Searcher.create(ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX_ACTORS);
// Create a SearchBoxViewModel with your SearchBox
searchBoxViewModel = new SearchBoxViewModel(this.findViewById(R.id.include_searchbox););
// Link it to your search widgets
new InstantSearch(this, searcherMovies).registerSearchView(this, searchBoxViewModel);
new InstantSearch(this, searcherActors).registerSearchView(this, searchBoxViewModel);
```
(Will write a guide once the PR is approved 😉)