### PR TITLE
Improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@
 buildscript {
     System.properties['com.android.build.gradle.overrideVersionCheck'] = 'true'
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.0'
@@ -16,8 +16,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven { url "https://jitpack.io" }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.databinding.enableV2=true

--- a/instantsearch/build.gradle
+++ b/instantsearch/build.gradle
@@ -75,8 +75,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api 'com.algolia:algoliasearch-android:3.20.11' // MavenCentral rejects X.+ notation
-    api 'org.greenrobot:eventbus:3.1.1'
-    api 'com.github.bumptech.glide:glide:4.3.1'
+    implementation 'org.greenrobot:eventbus:3.1.1'
+    implementation 'com.github.bumptech.glide:glide:4.3.1'
     implementation('com.jayway.jsonpath:json-path:2.3.0') {
         exclude module: 'asm'
     }

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -517,10 +517,10 @@ public class Searcher {
     }
 
     /**
-     * Set a given facet as disjunctive or conjunctive.
+     * Sets a given facet as disjunctive or conjunctive.
      *
      * @param attribute The facet's name.
-     * @param isDisjunctive true to treat this facet as disjunctive (`OR`), false to treat it as conjunctive (`AND`, the default).
+     * @param isDisjunctive {@code true} to treat this facet as disjunctive (`OR`), false to treat it as conjunctive (`AND`, the default).
      * @return this {@link Searcher} for chaining.
      * */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -517,6 +517,21 @@ public class Searcher {
     }
 
     /**
+     * Set a given facet as disjunctive or conjunctive.
+     *
+     * @param attribute The facet's name.
+     * @param isDisjunctive true to treat this facet as disjunctive (`OR`), false to treat it as conjunctive (`AND`, the default).
+     * */
+    @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
+    public void setFacet(@NonNull String attribute, boolean isDisjunctive) {
+        if (isDisjunctive && disjunctiveFacets.contains(attribute)) {
+            disjunctiveFacets.add(attribute);
+        } else {
+            disjunctiveFacets.remove(attribute);
+        }
+    }
+
+    /**
      * Adds a facet refinement for the next queries.
      * <p>
      * <b>This method resets the current page to 0.</b>

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -521,14 +521,16 @@ public class Searcher {
      *
      * @param attribute The facet's name.
      * @param isDisjunctive true to treat this facet as disjunctive (`OR`), false to treat it as conjunctive (`AND`, the default).
+     * @return this {@link Searcher} for chaining.
      * */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
-    public void setFacet(@NonNull String attribute, boolean isDisjunctive) {
+    public Searcher setFacet(@NonNull String attribute, boolean isDisjunctive) {
         if (isDisjunctive && disjunctiveFacets.contains(attribute)) {
             disjunctiveFacets.add(attribute);
         } else {
             disjunctiveFacets.remove(attribute);
         }
+        return this;
     }
 
     /**


### PR DESCRIPTION
Hi Algolia,

Some explanations of my commits:

1. https://github.com/algolia/instantsearch-android/commit/e625f50d17cbfe7ee8f5e34fe116db0caba5e4ad
I tried to update my project to use data binding v2, but encountered an error.
The fix solution is to use data binding v2 in your SDK.
![db](https://user-images.githubusercontent.com/25004194/41161988-cd110a42-6b34-11e8-8ae4-96e3c74322a9.png)

2. https://github.com/algolia/instantsearch-android/commit/585c62fb3798ffc917189d17fd3d3781af0450f2
I use lower version of glide, which has a conflict with your SDK, because the SDK expose its dependencies to me.
So I should do this in my gradle file:
```
api('com.algolia:instantsearch-android:1.8.2') {
    exclude group: 'com.github.bumptech.glide'
}
```
It may be better if simply we do not expose these dependencies of your SDK to users.

3. https://github.com/algolia/instantsearch-android/commit/ba12166820292420d726e9611b1c6b043750b086
I need to mark all my 40 facets as disjunctive without setting values.
I can do for example `searcher.addFacetRefinement("universe.facet.fr", emptyList(), true)`.
This code generates spams in the query:
```
"params": "analytics=false&attributesToHighlight=[]&attributesToRetrieve=[]&attributesToSnippet=[]&facetFilters=(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),(),()&facets=["universe.facet.fr"]&filters=("genders.ids"=1)&hitsPerPage=0&page=0"
```
By adding the method `setFacet` just like on iOS, I will be able to call simply `searcher.setFacet("universe.facet.fr", true)`. And the query will become more clean.
```
"params": "analytics=false&attributesToHighlight=[]&attributesToRetrieve=[]&attributesToSnippet=[]&facetFilters=&facets=["universe.facet.fr"]&filters=("genders.ids"=1)&hitsPerPage=0&page=0"
```
