### PR TITLE
feat(searchclient): Improve the searchClient

### DIFF
--- a/instantsearch/src/main/java/com/algolia/instantsearch/searchclient/DefaultSearchClient.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/searchclient/DefaultSearchClient.java
@@ -1,0 +1,20 @@
+package com.algolia.instantsearch.searchclient;
+
+import android.support.annotation.NonNull;
+
+import com.algolia.search.saas.Query;
+
+import org.json.JSONObject;
+
+public class DefaultSearchClient extends SearchClient<Query, JSONObject> {
+
+    @Override
+    public Query map(@NonNull Query query) {
+        return query;
+    }
+
+    @Override
+    public JSONObject map(@NonNull JSONObject customSearchResults) {
+        return customSearchResults;
+    }
+}

--- a/instantsearch/src/main/java/com/algolia/instantsearch/searchclient/SearchResultsHandler.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/searchclient/SearchResultsHandler.java
@@ -23,7 +23,7 @@
  *
  */
 
-package com.algolia.instantsearch.transformer;
+package com.algolia.instantsearch.searchclient;
 
 /**
  * Handles completion of a custom back-end API request.

--- a/instantsearch/src/main/java/com/algolia/instantsearch/searchclient/Transformable.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/searchclient/Transformable.java
@@ -21,13 +21,14 @@
  * THE SOFTWARE.
  */
 
-package com.algolia.instantsearch.transformer;
+package com.algolia.instantsearch.searchclient;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.algolia.instantsearch.model.SearchResults;
 import com.algolia.search.saas.Query;
+import com.algolia.search.saas.Request;
 
 import org.json.JSONObject;
 
@@ -42,7 +43,7 @@ public interface Transformable<Parameters, Results> {
      * @param query Search parameters. May be null to use an empty query.
      * @param completionHandler The listener that will be notified of the request's outcome.
      */
-    void search(@Nullable Parameters query, @Nullable SearchResultsHandler<Results> completionHandler);
+    Request search(@Nullable Parameters query, @Nullable SearchResultsHandler<Results> completionHandler);
 
     /***
      * Transforms the Algolia params to custom backend params.

--- a/instantsearch/src/main/java/com/algolia/instantsearch/searchclient/Transformable.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/searchclient/Transformable.java
@@ -78,7 +78,7 @@ public interface Transformable<Parameters, Results> {
      * @param query Search parameters. May be null to use an empty query.
      * @param completionHandler The listener that will be notified of the request's outcome.
      */
-    void searchForFacetValues(@NonNull Parameters query, @Nullable SearchResultsHandler<Results> completionHandler);
+    Request searchForFacetValues(@NonNull Parameters query, @Nullable SearchResultsHandler<Results> completionHandler);
 
 
     /***


### PR DESCRIPTION
- Rename from `SerachTransformer` to `SearchClient` (same for interfaces)
- Add `searchDisjunctiveFaceting` and `searchForFacetValues` method (basic) support.
- Abstract calling the map functions away from the 3rd party dev
- Introduce DefaultSearchClient for default cases when just need to forward Algolia requests/responses without any transformation
- Bug in SearchClient where it should take a `Request` instead of `Void`