### PR TITLE
Use gradle 4.4 with android build tool 3.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
+++ b/instantsearch/src/main/java/com/algolia/instantsearch/helpers/Searcher.java
@@ -525,7 +525,7 @@ public class Searcher {
      * */
     @SuppressWarnings({"WeakerAccess", "unused"}) // For library users
     public Searcher setFacet(@NonNull String attribute, boolean isDisjunctive) {
-        if (isDisjunctive && disjunctiveFacets.contains(attribute)) {
+        if (isDisjunctive && !disjunctiveFacets.contains(attribute)) {
             disjunctiveFacets.add(attribute);
         } else {
             disjunctiveFacets.remove(attribute);


### PR DESCRIPTION
Hello @PLNech 

In my last pull request https://github.com/algolia/instantsearch-android/pull/83 I forgot to update android build tool. Therefore the line of code which activates data binding v2 does not work. So here is a new PR to fix it. Sorry for the mistake 
c.f. https://developer.android.com/topic/libraries/data-binding/start#preview-compiler