### PR TITLE
fix(gradle): Expose EventBus to enable listening to events

### DIFF
--- a/instantsearch/build.gradle
+++ b/instantsearch/build.gradle
@@ -75,7 +75,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api 'com.algolia:algoliasearch-android:3.20.11' // MavenCentral rejects X.+ notation
-    implementation 'org.greenrobot:eventbus:3.1.1'
+    api 'org.greenrobot:eventbus:3.1.1'
     implementation 'com.github.bumptech.glide:glide:4.3.1'
     implementation('com.jayway.jsonpath:json-path:2.3.0') {
         exclude module: 'asm'


### PR DESCRIPTION
The change in b960f46 actually prevents apps to implement event `Subscribe`rs, unless they pull themselves the EventBus library.

![image](https://user-images.githubusercontent.com/1821404/43005979-f6fc789a-8c23-11e8-967b-204e0b8c8a32.png)


As this would risk a mismatch between the library's version and the app's, I would rather expose EventBus as an `api` (users can always strip them from the released app using Proguard if they really want to get rid of the 50k EventBus adds).