### PR TITLE
chore: Fix Jitpack dependent build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -118,8 +118,8 @@ def update_deps_to_use_commit_hash_if_workflow_triggered_by_client
   hash = ENV['GIT_DEPENDENT_COMMIT_HASH']
   if hash
     file_edit("../libraries.gradle", /^.*com.algolia:algoliasearch-android:.*$/m,
-    "            \"algolia\"          : \"com.algolia:algoliasearch-android:#{hash}\",")
-    puts "Changed gradle libraries to build with algoliasearch-client-android with commit #{hash}"
+    "            \"algolia\"          : \"com.github.algolia:algoliasearch-client-android:#{hash}\",")
+    puts "Changed gradle libraries to build with algoliasearch-client-android with commit #{hash}."
   else
     puts "No specific dependencies to test, proceeding with latest release of API Client."
   end

--- a/ui/build.gradle
+++ b/ui/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     api project(':core')
 
+    implementation libraries.appcompat
     implementation libraries.glide
     implementation libraries.recyclerview
     implementation libraries.constraint_layout


### PR DESCRIPTION
**Summary**

1. Mark `appcompat` as explicit dependency in `ui`, as implicitely pulling `project(':core')` was failing in Jitpack-based test builds
2. Fix Jitpack's URL missing `.github` prefix

**Result**
Before 1.:
```                                                                            ^
  symbol:   class SearchView
  location: package android.support.v7.widget
16 errors

FAILURE: Build failed with an exception.
```
After 1.:
```
BUILD SUCCESSFUL in 25s
```

2. Will be tested on next client test after this PR is merged.