### PR TITLE
chore: Use bintrayv with gpg & mavenCentralSync

### DIFF
--- a/release.gradle
+++ b/release.gradle
@@ -38,4 +38,4 @@ task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
 }
 
-apply from: 'https://raw.githubusercontent.com/algolia/instantsearch-mobile-tools/b5da94b/gradle/bintrayv.gradle'
+apply from: 'https://raw.githubusercontent.com/algolia/instantsearch-mobile-tools/d91fc7/gradle/bintrayv.gradle'


### PR DESCRIPTION
# Summary
Uses new bintrayv.gradle with GPG signing and MavenCentral Sync (requiring the former):
```diff
diff --git a/gradle/bintrayv.gradle b/gradle/bintrayv.gradle
index 17ab9bc..7287827 100644
--- a/gradle/bintrayv.gradle
+++ b/gradle/bintrayv.gradle
@@ -127,6 +127,14 @@ bintray {
             desc = "Version $VERSION"
             released = new Date()
             vcsTag = VERSION
+            
+            gpg {
+                sign = true
+            }
+            mavenCentralSync {
+                user = System.getenv('NEXUS_USERNAME')
+                password = System.getenv('NEXUS_PASSWORD')
+            }      
         }
     }
 }
```
# Result
- Should restore sync in Maven Central. Will release latest changes (#137) to confirm that!