### PR TITLE
chore: Deprecate v1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 InstantSearch family: **InstantSearch Android** | [InstantSearch iOS][instantsearch-ios-github] | [React InstantSearch][react-instantsearch-github] | [InstantSearch.js][instantsearch-js-github] | [Angular InstantSearch][instantsearch-angular-github] | [Vue InstantSearch][instantsearch-vue-github].
 
+# Deprecation
+
+**This version of InstantSearch Android is deprecated in favor of V2**: the new version offers a **better architecture**, **more features**, and is **easier to customize**.   
+
+See our [migration guide][migration-guide] - the V1 will only **get security fixes**, while **new Algolia features are implemented in V2**.
+
+----
+
 
 **InstantSearch Android** is a library providing widgets and helpers to help you build the best instant-search experience on Android with Algolia.
 It is built on top of Algolia's [Android API Client](https://github.com/algolia/algoliasearch-client-android) to provide you a high-level solution to quickly build various search interfaces.
@@ -61,6 +69,7 @@ From [reporting bugs or missing functionality](https://github.com/algolia/instan
 
 InstantSearch Android is [MIT licensed](LICENSE.md).
 
+[migration-guide]: https://algolia.com/doc/guides/building-search-ui/upgrade-guides/android/
 [react-instantsearch-github]: https://github.com/algolia/react-instantsearch/
 [instantsearch-ios-github]: https://github.com/algolia/instantsearch-ios
 [instantsearch-js-github]: https://github.com/algolia/instantsearch.js

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ InstantSearch family: **InstantSearch Android** | [InstantSearch iOS][instantsea
 
 **This version of InstantSearch Android is deprecated in favor of V2**: the new version offers a **better architecture**, **more features**, and is **easier to customize**.   
 
-See our [migration guide][migration-guide] - the V1 will only **get security fixes**, while **new Algolia features are implemented in V2**.
+See our [migration guide][migration-guide] - the V1 will only get **security fixes**, while **new Algolia features are implemented in V2**.
 
 ----
 

--- a/core/src/main/java/com/algolia/instantsearch/core/helpers/Searcher.java
+++ b/core/src/main/java/com/algolia/instantsearch/core/helpers/Searcher.java
@@ -55,7 +55,13 @@ import static com.algolia.instantsearch.core.events.ResultEvent.REQUEST_UNKNOWN;
  * The Searcher is responsible of interacting with the Algolia engine: when {@link Searcher#search()} is called,
  * the Searcher will fire a request with the current {@link Searcher#query}, and will forward the search results
  * (or error) to its {@link AlgoliaResultsListener result listeners} (or {@link AlgoliaErrorListener error listeners}).
+ *
+ * @see <a href="http://algolia.com/doc/guides/building-search-ui/upgrade-guides/android/">migration guide</a> - the V1 will <b>only get security fixes</b>, while <b>new Algolia features are implemented in V2</b>.
+ * @deprecated The V1 version of InstantSearch has been <b>deprecated in favor of V2</b>: the new version
+ * offers a better architecture, more features, and is easier to customize.
+ * See our <a href="http://algolia.com/doc/guides/building-search-ui/upgrade-guides/android/">migration guide</a> - the V1 will <b>only get security fixes</b>, while <b>new Algolia features are implemented in V2</b>.
  */
+@Deprecated
 @SuppressWarnings("UnusedReturnValue") // chaining
 public class Searcher {
     private static Map<String, Searcher> instances = new HashMap<>();

--- a/ui/src/main/java/com/algolia/instantsearch/ui/helpers/InstantSearch.java
+++ b/ui/src/main/java/com/algolia/instantsearch/ui/helpers/InstantSearch.java
@@ -48,7 +48,14 @@ import java.util.Set;
 /**
  * Uses the {@link Searcher} to react to changes in your application's interface, like when your user types a new query or interacts with Widgets.
  * You can either use it with a single widget which will receive incoming results, or with several that will interact together in the same activity.
+ *
+ * @deprecated The V1 version of InstantSearch has been <b>deprecated in favor of V2</b>: the new version
+ * offers a better architecture, more features, and is easier to customize.
+ * See our <a href="http://algolia.com/doc/guides/building-search-ui/upgrade-guides/android/">migration guide</a> - the V1 will <b>only get security fixes</b>, while <b>new Algolia features are implemented in V2</b>.
+ *
+ * @see <a href="http://algolia.com/doc/guides/building-search-ui/upgrade-guides/android/">migration guide</a> - the V1 will <b>only get security fixes</b>, while <b>new Algolia features are implemented in V2</b>.
  */
+@Deprecated
 public class InstantSearch {
     //TODO: migrate return void -> return Searcher for chaining methods
     /** Delay before displaying progressbar when the current android API does not support animations. {@literal (API < 14)} */


### PR DESCRIPTION
Announces deprecation of ISv1 in favor of ISv2.
![image](https://user-images.githubusercontent.com/1821404/62777979-62bb5c80-baaf-11e9-87df-4b94f87d1d1c.png)

Deprecation message:
> The V1 version of InstantSearch has been **deprecated in favor of V2**: the new version offers a better architecture, more features, and is easier to customize. See our [migration guide][1]  - the V1 will only **get security fixes**, while **new Algolia features are implemented in V2**.

- Marks `Searcher` and `InstantSearch` as deprecated
- Links to the (to be written) [Migration Guide][1]

[1]: https://deploy-preview-3505--algolia-doc.netlify.com/doc/guides/building-search-ui/upgrade-guides/android/