### PR TITLE
Feature/connect filter state searcher multiple

### DIFF
--- a/helper/build.gradle.kts
+++ b/helper/build.gradle.kts
@@ -18,11 +18,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion(28)
+    compileSdkVersion(29)
 
     defaultConfig {
         minSdkVersion(17)
-        targetSdkVersion(28)
+        targetSdkVersion(29)
         versionCode = 1
         versionName = "1.0"
 

--- a/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/list/SearcherMultipleIndexDataSource.kt
+++ b/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/list/SearcherMultipleIndexDataSource.kt
@@ -5,7 +5,6 @@ import androidx.paging.PageKeyedDataSource
 import com.algolia.instantsearch.helper.searcher.SearcherMultipleIndex
 import com.algolia.search.model.multipleindex.IndexQuery
 import com.algolia.search.model.response.ResponseSearch
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
@@ -31,7 +30,7 @@ public class SearcherMultipleIndexDataSource<T>(
     private var initialLoadSize: Int = 30
 
     init {
-        if (index == -1) throw IllegalArgumentException("The IndexQuery is not present in SearcherMultipleIndex")
+        require(index != -1) { "The IndexQuery is not present in SearcherMultipleIndex" }
     }
 
     override fun loadInitial(params: LoadInitialParams<Int>, callback: LoadInitialCallback<Int, T>) {

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/searcher/SearcherConnection.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/searcher/SearcherConnection.kt
@@ -4,6 +4,7 @@ import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.core.searcher.Debouncer
 import com.algolia.instantsearch.core.searcher.debounceFilteringInMillis
 import com.algolia.instantsearch.helper.filter.state.FilterState
+import com.algolia.search.model.IndexName
 
 
 public fun SearcherSingleIndex.connectFilterState(
@@ -18,4 +19,12 @@ public fun SearcherForFacets.connectFilterState(
     debouncer: Debouncer = Debouncer(debounceFilteringInMillis)
 ): Connection {
     return SearcherForFacetsConnectionFilterState(this, filterState, debouncer)
+}
+
+public fun SearcherMultipleIndex.connectFilterState(
+    filterState: FilterState,
+    indexName: IndexName,
+    debouncer: Debouncer = Debouncer(debounceFilteringInMillis)
+): Connection {
+    return SearcherMultipleConnectionFilterState(this, filterState, indexName, debouncer)
 }

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/searcher/SearcherMultipleConnectionFilterState.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/searcher/SearcherMultipleConnectionFilterState.kt
@@ -1,0 +1,47 @@
+package com.algolia.instantsearch.helper.searcher
+
+import com.algolia.instantsearch.core.Callback
+import com.algolia.instantsearch.core.connection.ConnectionImpl
+import com.algolia.instantsearch.core.searcher.Debouncer
+import com.algolia.instantsearch.helper.filter.state.FilterState
+import com.algolia.instantsearch.helper.filter.state.Filters
+import com.algolia.instantsearch.helper.filter.state.toFilterGroups
+import com.algolia.search.model.IndexName
+import com.algolia.search.model.filter.FilterGroupsConverter
+
+
+internal data class SearcherMultipleConnectionFilterState(
+    private val searcher: SearcherMultipleIndex,
+    private val filterState: FilterState,
+    private val indexName: IndexName,
+    private val debouncer: Debouncer
+) : ConnectionImpl() {
+
+    private val updateSearcher: Callback<Filters> = { filters ->
+        searcher.updateFilters(filters)
+        debouncer.debounce(searcher) { searcher.searchAsync().join() }
+    }
+
+    private val index = searcher.queries.indexOfFirst { it.indexName == indexName }
+
+    init {
+        require(index != -1) {
+            "No Index \"$indexName\" present in searcher current indices ${searcher.queries.map { it.indexName }}."
+        }
+        searcher.updateFilters()
+    }
+
+    override fun connect() {
+        super.connect()
+        filterState.filters.subscribe(updateSearcher)
+    }
+
+    override fun disconnect() {
+        super.disconnect()
+        filterState.filters.unsubscribe(updateSearcher)
+    }
+
+    private fun SearcherMultipleIndex.updateFilters(filters: Filters = filterState) {
+        queries[index].query.filters = FilterGroupsConverter.SQL(filters.toFilterGroups())
+    }
+}

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/searcher/SearcherMultipleConnectionFilterState.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/searcher/SearcherMultipleConnectionFilterState.kt
@@ -26,7 +26,7 @@ internal data class SearcherMultipleConnectionFilterState(
 
     init {
         require(index != -1) {
-            "No Index \"$indexName\" present in searcher current indices ${searcher.queries.map { it.indexName }}."
+            "No Index \"$indexName\" present in searcher current indices: ${searcher.queries.map { it.indexName }}."
         }
         searcher.updateFilters()
     }

--- a/helper/src/commonTest/kotlin/searcher/TestSearcherMultipleIndex.kt
+++ b/helper/src/commonTest/kotlin/searcher/TestSearcherMultipleIndex.kt
@@ -1,0 +1,54 @@
+package searcher
+
+import com.algolia.instantsearch.helper.filter.state.FilterState
+import com.algolia.instantsearch.helper.filter.state.filters
+import com.algolia.instantsearch.helper.filter.state.groupAnd
+import com.algolia.instantsearch.helper.searcher.SearcherMultipleIndex
+import com.algolia.instantsearch.helper.searcher.connectFilterState
+import com.algolia.search.model.IndexName
+import com.algolia.search.model.multipleindex.IndexQuery
+import com.algolia.search.model.response.ResponseSearches
+import mockClient
+import respondJson
+import shouldBeNull
+import shouldEqual
+import shouldFailWith
+import kotlin.test.Test
+
+
+class TestSearcherMultipleIndex {
+
+    private val client = mockClient(respondJson(ResponseSearches(listOf()), ResponseSearches.serializer()))
+    private val filterState = FilterState(
+        filters {
+            group(groupAnd("group")) {
+                facet("color", "red")
+            }
+        }
+    )
+    private val indexA = IndexName("indexA")
+    private val indexB = IndexName("indexB")
+    private val indexC = IndexName("indexC")
+    private val queries = listOf(
+        IndexQuery(indexA),
+        IndexQuery(indexB)
+    )
+    private val searcher = SearcherMultipleIndex(client, queries)
+
+    @Test
+    fun connectShouldUpdateProperQueryFilters() {
+        val index = searcher.queries[0]
+
+        index.query.filters.shouldBeNull()
+        searcher.connectFilterState(filterState, indexA).connect()
+        index.query.filters shouldEqual "(\"color\":\"red\")"
+        searcher.queries[1].query.filters.shouldBeNull()
+    }
+
+    @Test
+    fun connectWithWrongIndexShouldThrowException() {
+        IllegalArgumentException::class.shouldFailWith {
+            searcher.connectFilterState(filterState, indexC)
+        }
+    }
+}


### PR DESCRIPTION
As request by a customer, a method to connect a `FilterState` to a `SearcherMultipleIndex`.

User has to specify using `IndexName` as parameter, which `IndexQuery` should be tied to a `FilterState` instance.