### PR TITLE
Connect SortByViewModel with PagedList

### DIFF
--- a/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnection.kt
+++ b/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnection.kt
@@ -6,11 +6,10 @@ import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.helper.sortby.SortByConnector
 import com.algolia.instantsearch.helper.sortby.SortByViewModel
 
-
 public fun <T> SortByViewModel.connectPagedList(pagedList: LiveData<PagedList<T>>): Connection {
     return SortByConnectionPagedList(this, pagedList)
 }
 
 public fun <T> SortByConnector.connectPagedList(pagedList: LiveData<PagedList<T>>): Connection {
-    return SortByConnectionPagedList(viewModel, pagedList)
+    return viewModel.connectPagedList(pagedList)
 }

--- a/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnection.kt
+++ b/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnection.kt
@@ -1,0 +1,16 @@
+package com.algolia.instantsearch.helper.android.sortby
+
+import androidx.lifecycle.LiveData
+import androidx.paging.PagedList
+import com.algolia.instantsearch.core.connection.Connection
+import com.algolia.instantsearch.helper.sortby.SortByConnector
+import com.algolia.instantsearch.helper.sortby.SortByViewModel
+
+
+public fun <T> SortByViewModel.connectPagedList(pagedList: LiveData<PagedList<T>>): Connection {
+    return SortByConnectionPagedList(this, pagedList)
+}
+
+public fun <T> SortByConnector.connectPagedList(pagedList: LiveData<PagedList<T>>): Connection {
+    return SortByConnectionPagedList(viewModel, pagedList)
+}

--- a/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnectionPagedList.kt
+++ b/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnectionPagedList.kt
@@ -6,7 +6,6 @@ import com.algolia.instantsearch.core.Callback
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.helper.sortby.SortByViewModel
 
-
 internal class SortByConnectionPagedList<T>(
     private val viewModel: SortByViewModel,
     private val pagedList: LiveData<PagedList<T>>

--- a/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnectionPagedList.kt
+++ b/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnectionPagedList.kt
@@ -1,0 +1,28 @@
+package com.algolia.instantsearch.helper.android.sortby
+
+import androidx.lifecycle.LiveData
+import androidx.paging.PagedList
+import com.algolia.instantsearch.core.Callback
+import com.algolia.instantsearch.core.connection.ConnectionImpl
+import com.algolia.instantsearch.helper.sortby.SortByViewModel
+
+
+internal class SortByConnectionPagedList<T>(
+    private val viewModel: SortByViewModel,
+    private val pagedList: LiveData<PagedList<T>>
+) : ConnectionImpl() {
+
+    private val onSelection: Callback<Int?> = {
+        pagedList.value?.dataSource?.invalidate()
+    }
+
+    override fun connect() {
+        super.connect()
+        viewModel.eventSelection.subscribe(onSelection)
+    }
+
+    override fun disconnect() {
+        super.disconnect()
+        viewModel.eventSelection.unsubscribe(onSelection)
+    }
+}

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/searchbox/SearchBoxConnection.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/searchbox/SearchBoxConnection.kt
@@ -8,7 +8,6 @@ import com.algolia.instantsearch.core.searcher.Debouncer
 import com.algolia.instantsearch.core.searcher.Searcher
 import com.algolia.instantsearch.core.searcher.debounceSearchInMillis
 
-
 public fun <R> SearchBoxViewModel.connectSearcher(
     searcher: Searcher<R>,
     searchMode: SearchMode = SearchMode.AsYouType,


### PR DESCRIPTION
This connection is useful when using a _SortByConnector / SortByViewModel_ with a paginated list.

Each selection event of the _SortBy_ widget invalidates the datasource to refresh the underlying data with the proper index.