### PR TITLE
fix(pagedList): Potential fix when typing quickly in searchBar

### DIFF
--- a/buildSrc/src/main/kotlin/dependency/Library.kt
+++ b/buildSrc/src/main/kotlin/dependency/Library.kt
@@ -5,7 +5,7 @@ object Library: Dependency  {
 
     override val group = "com.algolia"
     override val artifact = "instantsearch"
-    override val version = "2.3.0"
+    override val version = "2.3.1"
 
     val packageName = "$group:$artifact-android"
 

--- a/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -30,9 +30,13 @@ public class SearcherSingleIndexDataSource<T>(
         searcher.query.hitsPerPage = initialLoadSize
         searcher.query.page = 0
         searcher.isLoading.value = true
+        val queryLoaded = searcher.query.query
         runBlocking {
             try {
                 val response = searcher.search()
+                if (queryLoaded != searcher.query.query) {
+                    invalidate()
+                }
                 val nextKey = if (response.nbHits > initialLoadSize) 1 else null
 
                 withContext(searcher.coroutineScope.coroutineContext) {


### PR DESCRIPTION
This happens because in the `LoadInitial` of the DataSource, we execute a search and block the thread. 

When a new request is made while the current search is being made, InstantSearch will try to `invalidate` the pagedList, but this will fail as the LoadInitial is still ongoing and doing some work. 
It follows that we don't get the latest query that the user entered in the search bar. 