### PR TITLE
fix(SpannedString): apply the correct spans in toSpannedString extension 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.2
+
+- Fix `toSpannedString` extension to apply the correct spans.
+
 # 2.3.1
 
 - Fix PagedList Bug when typing too fast #194

--- a/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/highlighting/Extensions.kt
+++ b/helper/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/highlighting/Extensions.kt
@@ -3,20 +3,26 @@ package com.algolia.instantsearch.helper.android.highlighting
 import android.graphics.Typeface
 import android.text.ParcelableSpan
 import android.text.SpannedString
+import android.text.style.CharacterStyle
 import android.text.style.StyleSpan
 import androidx.core.text.buildSpannedString
 import androidx.core.text.inSpans
 import com.algolia.instantsearch.core.highlighting.HighlightedString
 
-
 public fun HighlightedString.toSpannedString(
     span: ParcelableSpan = StyleSpan(Typeface.BOLD)
 ): SpannedString = buildSpannedString {
     tokens.forEach { (part, isHighlighted) ->
-        if (isHighlighted) inSpans(span) { append(part) }
+        if (isHighlighted) inSpans(span.wrap()) { append(part) }
         else append(part)
     }
 }
+
+/**
+ * A given [CharacterStyle] can only applied to a single region of a given Spanned.
+ * This method wraps a [ParcelableSpan] with a new object (if it is a [CharacterStyle]) that will have the same effect.
+ */
+internal fun ParcelableSpan.wrap(): Any = if (this is CharacterStyle) CharacterStyle.wrap(this) else this
 
 public fun List<HighlightedString>.toSpannedString(
     span: ParcelableSpan = StyleSpan(Typeface.BOLD)

--- a/helper/src/androidTest/kotlin/highlighting/TestExtensions.kt
+++ b/helper/src/androidTest/kotlin/highlighting/TestExtensions.kt
@@ -14,6 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
 import com.algolia.instantsearch.core.highlighting.HighlightTokenizer
 import com.algolia.instantsearch.helper.android.highlighting.toSpannedString
+import com.algolia.instantsearch.helper.android.highlighting.wrap
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -26,7 +27,7 @@ import shouldEqual
 class TestExtensions {
 
     private val tokenizer = HighlightTokenizer("[", "]")
-    private val highlightStrings = listOf("foo[ba]r", "foo[ba]r[ba]z")
+    private val highlightStrings = listOf("foo[ba]r", "foo[ba]r[ba]z") // 3 spans
     private val highlights = highlightStrings.map(tokenizer)
     private val defaultSpan = StyleSpan(Typeface.BOLD)
     private val customSpan = ForegroundColorSpan(Color.RED)
@@ -35,13 +36,13 @@ class TestExtensions {
         return listOf(
             buildSpannedString {
                 append("foo")
-                inSpans(span) { append("ba") }
+                inSpans(span.wrap()) { append("ba") }
                 append("r")
             }, buildSpannedString {
                 append("foo")
-                inSpans(span) { append("ba") }
+                inSpans(span.wrap()) { append("ba") }
                 append("r")
-                inSpans(span) { append("ba") }
+                inSpans(span.wrap()) { append("ba") }
                 append("z")
             }
         )
@@ -81,7 +82,7 @@ class TestExtensions {
         val expectedSpannedStrings = expectedSpannedStrings(customSpan)
 
         tested.toString() shouldEqual expectedSpannedStrings.joinToString() // Built strings are the same
-        tested.getSpans<Any>().size shouldEqual 1                           // and tested does still have its span
+        tested.getSpans<Any>().size shouldEqual 3                           // and tested does still have its span
     }
 
     private inline fun <reified T : Any> SpannedString.getSpans(): Array<out T> {


### PR DESCRIPTION
`HighlightedString.toSpannedString(ParcelableSpan)` used the same object to apply spans. 
However, a given `CharacterStyle` can only applied to a single region of a given Spanned.
