### PR TITLE
Attempt to fix #198 : updated algolia-client, AGP and Kotlin versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,8 @@ buildscript {
     }
     dependencies {
         classpath(dependency.script.AndroidTools())
-        classpath(kotlin("gradle-plugin", version = "1.3.60"))
-        classpath(kotlin("serialization",  version = "1.3.60"))
+        classpath(kotlin("gradle-plugin", version = "1.3.72"))
+        classpath(kotlin("serialization",  version = "1.3.72"))
         classpath("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
     }
 }

--- a/buildSrc/src/main/kotlin/dependency/network/AlgoliaClient.kt
+++ b/buildSrc/src/main/kotlin/dependency/network/AlgoliaClient.kt
@@ -7,5 +7,5 @@ object AlgoliaClient : Dependency {
 
     override val group = "com.algolia"
     override val artifact = "algoliasearch-client-kotlin"
-    override val version = "1.3.1"
+    override val version = "1.4.0-beta02"
 }

--- a/buildSrc/src/main/kotlin/dependency/script/AndroidTools.kt
+++ b/buildSrc/src/main/kotlin/dependency/script/AndroidTools.kt
@@ -6,5 +6,5 @@ object AndroidTools : Dependency {
 
     override val group = "com.android.tools.build"
     override val artifact = "gradle"
-    override val version = "3.5.2"
+    override val version = "3.6.3"
 }


### PR DESCRIPTION
# Summary

Fix #198 by updating algoliasearch-client that causes the crash

# Result

Build produced without errors: 

```
BUILD SUCCESSFUL in 40s
60 actionable tasks: 60 executed
18:30:00: Task execution finished 'assemble'.
```