### PR TITLE
Related items widget implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # 2.4.0
 
+## Added
+- Related items widget
+
 ### Changed
 - Kotlin `1.3.72`
 - Android Gradle Plugin `3.6.3`

--- a/buildSrc/src/main/kotlin/dependency/Library.kt
+++ b/buildSrc/src/main/kotlin/dependency/Library.kt
@@ -5,7 +5,7 @@ object Library: Dependency  {
 
     override val group = "com.algolia"
     override val artifact = "instantsearch"
-    override val version = "2.4.0-beta01"
+    override val version = "2.4.0-beta02"
 
     val packageName = "$group:$artifact-android"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/MatchingPattern.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/MatchingPattern.kt
@@ -1,0 +1,17 @@
+package com.algolia.instantsearch.helper.relateditems
+
+import com.algolia.search.model.Attribute
+import kotlin.reflect.KProperty1
+
+/**
+ * Representation of a scored filter based on a hit attribute.
+ *
+ * @param attribute hit's attribute
+ * @param score filter score
+ * @param property hit's property
+ */
+data class MatchingPattern<T>(
+    val attribute: Attribute,
+    val score: Int,
+    val property: KProperty1<T, *>
+)

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/SearcherConnectionRelatedItems.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/SearcherConnectionRelatedItems.kt
@@ -1,0 +1,26 @@
+package com.algolia.instantsearch.helper.relateditems
+
+import com.algolia.instantsearch.core.Presenter
+import com.algolia.instantsearch.core.connection.Connection
+import com.algolia.instantsearch.core.hits.HitsView
+import com.algolia.instantsearch.helper.relateditems.internal.RelatedItemsConnectionView
+import com.algolia.instantsearch.helper.searcher.SearcherSingleIndex
+import com.algolia.search.model.indexing.Indexable
+import com.algolia.search.model.response.ResponseSearch
+
+/**
+ * Connects [SearcherSingleIndex] to [HitsView] to display related items.
+ *
+ * @param adapter hits views adapter
+ * @param hit hit to get its related items
+ * @param matchingPatterns list of matching patterns that create scored filters based on the hit’s attributes
+ * @param presenter presentation output and format
+ */
+public fun <T> SearcherSingleIndex.connectHitsView(
+    adapter: HitsView<T>,
+    hit: T,
+    matchingPatterns: List<MatchingPattern<T>>,
+    presenter: Presenter<ResponseSearch, List<T>>
+): Connection where T : Indexable {
+    return RelatedItemsConnectionView(this, adapter, hit, matchingPatterns, presenter)
+}

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/SearcherConnectionRelatedItems.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/SearcherConnectionRelatedItems.kt
@@ -16,7 +16,7 @@ import com.algolia.search.model.response.ResponseSearch
  * @param matchingPatterns list of matching patterns that create scored filters based on the hit’s attributes
  * @param presenter presentation output and format
  */
-public fun <T> SearcherSingleIndex.connectHitsView(
+public fun <T> SearcherSingleIndex.connectRelatedHitsView(
     adapter: HitsView<T>,
     hit: T,
     matchingPatterns: List<MatchingPattern<T>>,

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/FilterFacetAndID.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/FilterFacetAndID.kt
@@ -3,7 +3,7 @@ package com.algolia.instantsearch.helper.relateditems.internal
 import com.algolia.instantsearch.helper.filter.state.FilterGroupID
 import com.algolia.search.model.filter.Filter
 
-internal class OptionalFilter(
+internal class FilterFacetAndID(
     val filterGroupID: FilterGroupID,
     val filterFacets: Array<Filter.Facet>
 )

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/OptionalFilter.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/OptionalFilter.kt
@@ -1,0 +1,9 @@
+package com.algolia.instantsearch.helper.relateditems.internal
+
+import com.algolia.instantsearch.helper.filter.state.FilterGroupID
+import com.algolia.search.model.filter.Filter
+
+internal class OptionalFilter(
+    val filterGroupID: FilterGroupID,
+    val filterFacets: Array<Filter.Facet>
+)

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/RelatedItemsConnectionView.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/RelatedItemsConnectionView.kt
@@ -1,0 +1,40 @@
+package com.algolia.instantsearch.helper.relateditems.internal
+
+import com.algolia.instantsearch.core.Callback
+import com.algolia.instantsearch.core.Presenter
+import com.algolia.instantsearch.core.connection.ConnectionImpl
+import com.algolia.instantsearch.core.hits.HitsView
+import com.algolia.instantsearch.helper.relateditems.MatchingPattern
+import com.algolia.instantsearch.helper.relateditems.internal.extensions.configureRelatedItems
+import com.algolia.instantsearch.helper.searcher.SearcherSingleIndex
+import com.algolia.search.model.indexing.Indexable
+import com.algolia.search.model.response.ResponseSearch
+
+internal data class RelatedItemsConnectionView<T>(
+    private val searcher: SearcherSingleIndex,
+    private val view: HitsView<T>,
+    private val hit: T,
+    private val matchingPatterns: List<MatchingPattern<T>>,
+    private val presenter: Presenter<ResponseSearch, List<T>>
+) : ConnectionImpl() where T : Indexable {
+
+    init {
+        searcher.configureRelatedItems(hit, matchingPatterns)
+    }
+
+    private val callback: Callback<ResponseSearch?> = { response ->
+        if (response != null) {
+            view.setHits(presenter(response))
+        }
+    }
+
+    override fun connect() {
+        super.connect()
+        searcher.response.subscribe(callback)
+    }
+
+    override fun disconnect() {
+        super.disconnect()
+        searcher.response.unsubscribe(callback)
+    }
+}

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/FilterState.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/FilterState.kt
@@ -1,0 +1,21 @@
+package com.algolia.instantsearch.helper.relateditems.internal.extensions
+
+import com.algolia.instantsearch.helper.filter.state.FilterOperator
+import com.algolia.instantsearch.helper.filter.state.FilterState
+import com.algolia.instantsearch.helper.relateditems.MatchingPattern
+import com.algolia.search.model.filter.Filter
+import com.algolia.search.model.filter.FilterGroup
+
+internal fun <T> FilterState.addMatchingPattern(hit: T, matchingPattern: MatchingPattern<T>) {
+    val optionalFilter = matchingPattern.toOptionalFilter(hit)
+    add(optionalFilter.filterGroupID, *optionalFilter.filterFacets)
+}
+
+internal fun FilterState.toFilterFacetGroup(): Set<FilterGroup<Filter.Facet>> {
+    return getFacetGroups().map { (key, value) ->
+        when (key.operator) {
+            FilterOperator.And -> FilterGroup.And.Facet(value, key.name)
+            FilterOperator.Or -> FilterGroup.Or.Facet(value, key.name)
+        }
+    }.toSet()
+}

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/Indexable.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/Indexable.kt
@@ -1,0 +1,13 @@
+package com.algolia.instantsearch.helper.relateditems.internal.extensions
+
+import com.algolia.search.model.Attribute
+import com.algolia.search.model.filter.Filter
+import com.algolia.search.model.filter.FilterGroup
+import com.algolia.search.model.filter.FilterGroupsConverter
+import com.algolia.search.model.indexing.Indexable
+
+internal fun Indexable.toNegatedFacetFilter(): List<List<String>> {
+    val filter = Filter.Facet(Attribute("objectID"), objectID.toString(), isNegated = true)
+    val filterGroups = setOf<FilterGroup<Filter.Facet>>(FilterGroup.And.Facet(filter))
+    return FilterGroupsConverter.Legacy.Facet(filterGroups).unquote()
+}

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/Indexable.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/Indexable.kt
@@ -6,8 +6,8 @@ import com.algolia.search.model.filter.FilterGroup
 import com.algolia.search.model.filter.FilterGroupsConverter
 import com.algolia.search.model.indexing.Indexable
 
-internal fun Indexable.toNegatedFacetFilter(): List<List<String>> {
-    val filter = Filter.Facet(Attribute("objectID"), objectID.toString(), isNegated = true)
+internal fun Indexable.toFacetFilter(isNegated: Boolean = false): List<List<String>> {
+    val filter = Filter.Facet(Attribute("objectID"), objectID.toString(), isNegated = isNegated)
     val filterGroups = setOf<FilterGroup<Filter.Facet>>(FilterGroup.And.Facet(filter))
     return FilterGroupsConverter.Legacy.Facet(filterGroups).unquote()
 }

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/MatchingPattern.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/MatchingPattern.kt
@@ -1,0 +1,35 @@
+package com.algolia.instantsearch.helper.relateditems.internal.extensions
+
+import com.algolia.instantsearch.helper.filter.state.FilterState
+import com.algolia.instantsearch.helper.filter.state.groupAnd
+import com.algolia.instantsearch.helper.filter.state.groupOr
+import com.algolia.instantsearch.helper.relateditems.MatchingPattern
+import com.algolia.instantsearch.helper.relateditems.internal.OptionalFilter
+import com.algolia.search.model.filter.Filter
+import com.algolia.search.model.filter.FilterGroupsConverter
+
+internal fun <T> List<MatchingPattern<T>>.toOptionalFilters(hit: T): List<List<String>>? {
+    val filterState = FilterState()
+    forEach { filterState.addMatchingPattern(hit, it) }
+    return FilterGroupsConverter.Legacy.Facet(filterState.toFilterFacetGroup()).unquote()
+}
+
+/**
+ * Create an [OptionalFilter] from a [MatchingPattern].
+ */
+internal fun <T> MatchingPattern<T>.toOptionalFilter(hit: T): OptionalFilter {
+    return when (val property = property.get(hit)) {
+        is Iterable<*> -> {
+            val groupOr = groupOr()
+            val list = property.map { value -> Filter.Facet(attribute, value.toString(), score) }.toTypedArray()
+            OptionalFilter(
+                groupOr,
+                list
+            )
+        }
+        else -> OptionalFilter(
+            groupAnd(),
+            arrayOf(Filter.Facet(attribute, property.toString(), score))
+        )
+    }
+}

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/MatchingPattern.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/MatchingPattern.kt
@@ -4,7 +4,7 @@ import com.algolia.instantsearch.helper.filter.state.FilterState
 import com.algolia.instantsearch.helper.filter.state.groupAnd
 import com.algolia.instantsearch.helper.filter.state.groupOr
 import com.algolia.instantsearch.helper.relateditems.MatchingPattern
-import com.algolia.instantsearch.helper.relateditems.internal.OptionalFilter
+import com.algolia.instantsearch.helper.relateditems.internal.FilterFacetAndID
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.filter.FilterGroupsConverter
 
@@ -15,19 +15,16 @@ internal fun <T> List<MatchingPattern<T>>.toOptionalFilters(hit: T): List<List<S
 }
 
 /**
- * Create an [OptionalFilter] from a [MatchingPattern].
+ * Create an [FilterFacetAndID] from a [MatchingPattern].
  */
-internal fun <T> MatchingPattern<T>.toOptionalFilter(hit: T): OptionalFilter {
+internal fun <T> MatchingPattern<T>.toOptionalFilter(hit: T): FilterFacetAndID {
     return when (val property = property.get(hit)) {
         is Iterable<*> -> {
             val groupOr = groupOr()
             val list = property.map { value -> Filter.Facet(attribute, value.toString(), score) }.toTypedArray()
-            OptionalFilter(
-                groupOr,
-                list
-            )
+            FilterFacetAndID(groupOr, list)
         }
-        else -> OptionalFilter(
+        else -> FilterFacetAndID(
             groupAnd(),
             arrayOf(Filter.Facet(attribute, property.toString(), score))
         )

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/SearcherSingleIndex.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/SearcherSingleIndex.kt
@@ -1,0 +1,16 @@
+package com.algolia.instantsearch.helper.relateditems.internal.extensions
+
+import com.algolia.instantsearch.helper.relateditems.MatchingPattern
+import com.algolia.instantsearch.helper.searcher.SearcherSingleIndex
+import com.algolia.search.model.indexing.Indexable
+
+internal fun <T> SearcherSingleIndex.configureRelatedItems(
+    hit: T,
+    patterns: List<MatchingPattern<T>>
+) where T : Indexable {
+    query.apply {
+        sumOrFiltersScores = true
+        facetFilters = hit.toNegatedFacetFilter()
+        optionalFilters = patterns.toOptionalFilters(hit)
+    }
+}

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/SearcherSingleIndex.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/SearcherSingleIndex.kt
@@ -10,7 +10,7 @@ internal fun <T> SearcherSingleIndex.configureRelatedItems(
 ) where T : Indexable {
     query.apply {
         sumOrFiltersScores = true
-        facetFilters = hit.toNegatedFacetFilter()
+        facetFilters = hit.toFacetFilter(true)
         optionalFilters = patterns.toOptionalFilters(hit)
     }
 }

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/Unquote.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/relateditems/internal/extensions/Unquote.kt
@@ -1,0 +1,10 @@
+package com.algolia.instantsearch.helper.relateditems.internal.extensions
+
+/**
+ * TODO: Replace and remove after https://github.com/algolia/algoliasearch-client-kotlin/issues/188
+ */
+internal fun List<List<String>>.unquote(): List<List<String>> {
+    return map { innerList ->
+        innerList.map { it.replace("\"", "") }
+    }
+}

--- a/helper/src/commonTest/kotlin/relatedItems/Product.kt
+++ b/helper/src/commonTest/kotlin/relatedItems/Product.kt
@@ -1,0 +1,13 @@
+package relatedItems
+
+import com.algolia.search.model.ObjectID
+import com.algolia.search.model.indexing.Indexable
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class Product(
+    override val objectID: ObjectID,
+    val name: String,
+    val brand: String,
+    val categories: List<String>
+) : Indexable

--- a/helper/src/commonTest/kotlin/relatedItems/TestMachingPattern.kt
+++ b/helper/src/commonTest/kotlin/relatedItems/TestMachingPattern.kt
@@ -1,0 +1,25 @@
+package relatedItems
+
+import com.algolia.instantsearch.helper.relateditems.MatchingPattern
+import com.algolia.search.model.Attribute
+import com.algolia.search.model.ObjectID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestMachingPattern {
+
+    @Test
+    fun matchingPattern_property() {
+        val objectID = ObjectID("objectID")
+        val name = "product"
+        val brand = "brand"
+        val categories = listOf("category")
+        val product = Product(objectID, name, brand, categories)
+
+        val patternBrand = MatchingPattern(Attribute("brand"), 1, Product::brand)
+        val patternCategories = MatchingPattern(Attribute("categories"), 1, Product::categories)
+
+        assertEquals(brand, patternBrand.property.get(product))
+        assertEquals(categories, patternCategories.property.get(product))
+    }
+}

--- a/helper/src/commonTest/kotlin/relatedItems/TestSearcherConnectionRelatedItems.kt
+++ b/helper/src/commonTest/kotlin/relatedItems/TestSearcherConnectionRelatedItems.kt
@@ -45,8 +45,6 @@ class TestSearcherConnectionRelatedItems {
             ),
             searcher.query.optionalFilters
         )
-
-        println(searcher.query)
     }
 
     private fun <T> mockHitsView(): HitsView<T> {

--- a/helper/src/commonTest/kotlin/relatedItems/TestSearcherConnectionRelatedItems.kt
+++ b/helper/src/commonTest/kotlin/relatedItems/TestSearcherConnectionRelatedItems.kt
@@ -1,0 +1,59 @@
+package relatedItems
+
+import com.algolia.instantsearch.core.hits.HitsView
+import com.algolia.instantsearch.helper.relateditems.MatchingPattern
+import com.algolia.instantsearch.helper.relateditems.connectRelatedHitsView
+import com.algolia.instantsearch.helper.searcher.SearcherSingleIndex
+import com.algolia.search.helper.deserialize
+import com.algolia.search.model.Attribute
+import com.algolia.search.model.IndexName
+import com.algolia.search.model.ObjectID
+import mockClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TestSearcherConnectionRelatedItems {
+
+    private val client = mockClient()
+    private val index = client.initIndex(IndexName("Index"))
+
+    @Test
+    fun connect() {
+        val searcher = SearcherSingleIndex(index)
+        val adapter = mockHitsView<Product>()
+
+        val patternBrand = MatchingPattern(Attribute("attBrand"), 1, Product::brand)
+        val patternCategories = MatchingPattern(Attribute("attCategories"), 1, Product::categories)
+        val matchingPatterns = listOf(patternBrand, patternCategories)
+
+        val product = Product(ObjectID("objectID"), "product", "brand", listOf("category1", "category2"))
+        val connection = searcher.connectRelatedHitsView(adapter, product, matchingPatterns) {
+            it.hits.deserialize(Product.serializer())
+        }
+
+        connection.connect()
+        assertTrue(searcher.query.sumOrFiltersScores!!)
+        assertEquals(listOf(listOf("objectID:-${product.objectID}")), searcher.query.facetFilters)
+        assertEquals(
+            listOf(
+                listOf("${patternBrand.attribute}:${product.brand}<score=${patternBrand.score}>"),
+                listOf(
+                    "${patternCategories.attribute}:${product.categories[0]}<score=${patternCategories.score}>",
+                    "${patternCategories.attribute}:${product.categories[1]}<score=${patternCategories.score}>"
+                )
+            ),
+            searcher.query.optionalFilters
+        )
+
+        println(searcher.query)
+    }
+
+    private fun <T> mockHitsView(): HitsView<T> {
+        return object : HitsView<T> {
+            override fun setHits(hits: List<T>) {
+                // Ignored.
+            }
+        }
+    }
+}

--- a/helper/src/commonTest/kotlin/relatedItems/TestSearcherConnectionRelatedItems.kt
+++ b/helper/src/commonTest/kotlin/relatedItems/TestSearcherConnectionRelatedItems.kt
@@ -24,7 +24,7 @@ class TestSearcherConnectionRelatedItems {
         val adapter = mockHitsView<Product>()
 
         val patternBrand = MatchingPattern(Attribute("attBrand"), 1, Product::brand)
-        val patternCategories = MatchingPattern(Attribute("attCategories"), 1, Product::categories)
+        val patternCategories = MatchingPattern(Attribute("attCategories"), 2, Product::categories)
         val matchingPatterns = listOf(patternBrand, patternCategories)
 
         val product = Product(ObjectID("objectID"), "product", "brand", listOf("category1", "category2"))


### PR DESCRIPTION
Related Items widget, follows same [iOS](https://www.algolia.com/doc/api-reference/widgets/configure-related-items/ios/) and [js](https://www.algolia.com/doc/api-reference/widgets/configure-related-items/js/) implementations.

```kotlin
@Serializable
data class Product(
    val name: String,
    val brand: String,
    val type: String,
    val categories: List<String>,
    val image: String,
    override val objectID: ObjectID
) : Indexable

val matchingPatterns: List<MatchingPattern<Product>> = listOf(
    MatchingPattern(Attribute("brand"), 1, Product::brand),
    MatchingPattern(Attribute("categories"), 2, Product::categories)
)

val index = client.initIndex(IndexName("stub"))
val searcher = SearcherSingleIndex(index)
val connection = ConnectionHandler()

val relatedItemsAdapter = ProductAdapter()
configureRecyclerView(relatedItems, relatedItemsAdapter)

val product = Product(/** init **/)
connection += searcher.connectRelatedHitsView(relatedItemsAdapter, product, matchingPatterns) { response ->
    response.hits.deserialize(Product.serializer())
}
```