### PR TITLE
fix(hierarchical): Remove unexpected sub-nodes from the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+# Fixed
+- Filter unexpected items from the hierarchical tree results
+
 # 2.5.0
 
 ## Added

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/hierarchical/HierarchicalConnectionSearcher.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/hierarchical/HierarchicalConnectionSearcher.kt
@@ -28,6 +28,14 @@ internal data class HierarchicalConnectionSearcher(
     /**
      * Removes results not matching the naming pattern.
      * This is a workaround to remove unexpected categories in results.
+     *
+     * Let's consider an item with the following filters:
+     * Level 0: [Clothing, Top]
+     * Level 1: [Clothing > Men, Clothing > Women, Top > T-shirts]
+     *
+     * In case of selecting 'Clothing' the tree will be:
+     * Level 0: [Clothing, Furniture]
+     * Level 1: [Clothing > Men, Clothing > Women]
      */
     private fun List<MutableList<Facet>>.filterUnprefixed(): List<MutableList<Facet>> {
         viewModel.hierarchicalPath.value.forEachIndexed { index, (_, item) ->

--- a/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/hierarchical/HierarchicalViewModel.kt
+++ b/helper/src/commonMain/kotlin/com/algolia/instantsearch/helper/hierarchical/HierarchicalViewModel.kt
@@ -20,6 +20,8 @@ public open class HierarchicalViewModel(
     public val selections = SubscriptionValue<List<String>>(listOf())
     public val eventHierarchicalPath = SubscriptionEvent<HierarchicalPath>()
 
+    internal val hierarchicalPath = SubscriptionValue<HierarchicalPath>(listOf())
+
     init {
         if (hierarchicalAttributes.isEmpty())
             throw IllegalArgumentException("HierarchicalAttributes should not be empty")
@@ -37,6 +39,7 @@ public open class HierarchicalViewModel(
             selections.getOrNull(index)?.let { item to it }
         }.filterNotNull()
 
+        this.hierarchicalPath.value = hierarchicalPath
         eventHierarchicalPath.send(hierarchicalPath)
     }
 


### PR DESCRIPTION
Filter unexpected sub-nodes in the tree. 
Solves the cases of expanding multiple nodes at the same time.