### PR TITLE
fix(transport): change ktor's http engine to okhttp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 2.7.0
 
 # Added
 - Query rule custom data widget

--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -4,5 +4,5 @@ object Library: Dependency {
 
     override val group = "com.algolia"
     override val artifact = "instantsearch-android"
-    override val version = "2.7.0-alpha01"
+    override val version = "2.7.0"
 }

--- a/instantsearch-android/build.gradle.kts
+++ b/instantsearch-android/build.gradle.kts
@@ -57,7 +57,7 @@ version = Library.version
 dependencies {
     api(project(":instantsearch-android-core"))
     api(AlgoliaClient())
-    api(Ktor("client-android"))
+    api(Ktor("client-okhttp"))
     api(AndroidCore("ktx"))
     api(AppCompat())
     api(RecyclerView())


### PR DESCRIPTION
Change ktor's engine from [Android](https://ktor.io/docs/http-client-engines.html#android) to [OkHttp](https://ktor.io/docs/http-client-engines.html#okhttp).

Android engine, at the moment, has a bug at the connection layer. It throws `java.net.SocketTimeoutException` instead of `ConnectTimeoutException`. The android engine is excepted to [transform native exceptions](https://github.com/ktorio/ktor/blob/87e4df338b2135dc1e9de91563756f9195db0ab1/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt#L77) into [Ktor's exceptions](https://github.com/ktorio/ktor/blob/87e4df338b2135dc1e9de91563756f9195db0ab1/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidURLConnectionUtils.kt#L56), however, due to unexpected behavior, the engine throws a [java exception](https://github.com/ktorio/ktor/blob/06b19ebd17d556cbbd6f763b6b5c77920171b0d2/ktor-client/ktor-client-android/jvm/src/io/ktor/client/engine/android/AndroidClientEngine.kt#L79) instead. Luckily, OkHttp engine works as expected, let's use it instead.