### PR TITLE
feat(search): enable/disable loading in PagedLists

### DIFF
--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherMultipleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherMultipleIndexDataSource.kt
@@ -11,17 +11,19 @@ import kotlinx.coroutines.withContext
 public class SearcherMultipleIndexDataSource<T>(
     private val searcher: SearcherMultipleIndex,
     private val indexQuery: IndexQuery,
+    private val loadEmptyQueries: Boolean = true,
     private val transformer: (ResponseSearch.Hit) -> T,
 ) : PageKeyedDataSource<Int, T>() {
 
     public class Factory<T>(
         private val searcher: SearcherMultipleIndex,
         private val indexQuery: IndexQuery,
+        private val loadEmptyQueries: Boolean = true,
         private val transformer: (ResponseSearch.Hit) -> T,
     ) : DataSource.Factory<Int, T>() {
 
         override fun create(): DataSource<Int, T> {
-            return SearcherMultipleIndexDataSource(searcher, indexQuery, transformer)
+            return SearcherMultipleIndexDataSource(searcher, indexQuery, loadEmptyQueries, transformer)
         }
     }
 
@@ -33,10 +35,13 @@ public class SearcherMultipleIndexDataSource<T>(
     }
 
     override fun loadInitial(params: LoadInitialParams<Int>, callback: LoadInitialCallback<Int, T>) {
+        if (!loadEmptyQueries && isAllQueriesNullOrEmpty()) return
+
         initialLoadSize = params.requestedLoadSize
         indexQuery.query.hitsPerPage = initialLoadSize
         indexQuery.query.page = 0
         searcher.isLoading.value = true
+
         runBlocking {
             try {
                 val response = searcher.search()
@@ -51,6 +56,12 @@ public class SearcherMultipleIndexDataSource<T>(
             } catch (throwable: Throwable) {
                 resultError(throwable)
             }
+        }
+    }
+
+    private fun isAllQueriesNullOrEmpty(): Boolean {
+        return searcher.queries.all { index ->
+            index.query.query.isNullOrEmpty()
         }
     }
 

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -4,23 +4,24 @@ import androidx.paging.DataSource
 import androidx.paging.PageKeyedDataSource
 import com.algolia.instantsearch.helper.searcher.SearcherSingleIndex
 import com.algolia.search.model.response.ResponseSearch
+import com.algolia.search.model.search.Query
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 public class SearcherSingleIndexDataSource<T>(
     private val searcher: SearcherSingleIndex,
-    private val loadEmptyQuery: Boolean = true,
+    private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
     private val transformer: (ResponseSearch.Hit) -> T,
 ) : PageKeyedDataSource<Int, T>() {
 
     public class Factory<T>(
         private val searcher: SearcherSingleIndex,
-        private val loadEmptyQuery: Boolean = true,
+        private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
         private val transformer: (ResponseSearch.Hit) -> T,
     ) : DataSource.Factory<Int, T>() {
 
         override fun create(): DataSource<Int, T> {
-            return SearcherSingleIndexDataSource(searcher, loadEmptyQuery, transformer)
+            return SearcherSingleIndexDataSource(searcher, triggerSearchForQuery, transformer)
         }
     }
 
@@ -28,7 +29,7 @@ public class SearcherSingleIndexDataSource<T>(
 
     override fun loadInitial(params: LoadInitialParams<Int>, callback: LoadInitialCallback<Int, T>) {
         val queryLoaded = searcher.query.query
-        if (!loadEmptyQuery && queryLoaded.isNullOrEmpty()) return
+        if (!triggerSearchForQuery(searcher.query)) return
 
         initialLoadSize = params.requestedLoadSize
         searcher.query.hitsPerPage = initialLoadSize


### PR DESCRIPTION
New `triggerSearchForQuery` parameter to enable/disable `PagedList` loading:
* Single Index: `(Query) -> Boolean)`
* Multiple Index: `(List<IndexQuery>) -> Boolean`

Example with Single Index and `triggerSearchForQuery = { query -> query.query?.isNotEmpty() == true }`:

![loadempty](https://user-images.githubusercontent.com/1970868/99412778-64501300-28f5-11eb-9749-5ff6752a6c8f.gif)

Fixes: #220 