### PR TITLE
chore(publishing): remove bintray from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <img src="docs/banner.png" alt="InstantSearch Android" />
 
-[ ![Download](https://api.bintray.com/packages/algolia/maven/com.algolia%3Ainstantsearch-android/images/download.svg) ](https://bintray.com/algolia/maven/com.algolia%3Ainstantsearch-android/_latestVersion)
+[ ![Download](https://img.shields.io/maven-central/v/com.algolia/instantsearch-android?label=Download) ](https://search.maven.org/search?q=a:instantsearch-android)
 [![Build Status](https://travis-ci.org/algolia/instantsearch-android.svg?branch=master)](https://travis-ci.org/algolia/instantsearch-android)
 
 InstantSearch family: **InstantSearch Android** | [InstantSearch iOS][instantsearch-ios-github] | [React InstantSearch][react-instantsearch-github] | [InstantSearch.js][instantsearch-js-github] | [Angular InstantSearch][instantsearch-angular-github] | [Vue InstantSearch][instantsearch-vue-github].


### PR DESCRIPTION
- [x] Update `README.md` badges
- [x] Publish the library from `2.6.0` to the latest (`2.8.0`) to Maven Central:
  - [x] [`2.8.0`](https://search.maven.org/artifact/com.algolia/instantsearch-android/2.8.0/aar)
  - [x] [`2.7.3`](https://search.maven.org/artifact/com.algolia/instantsearch-android/2.7.3/aar)
  - [x] [`2.7.2`](https://search.maven.org/artifact/com.algolia/instantsearch-android/2.7.2/aar)
  - [x] [`2.7.1`](https://search.maven.org/artifact/com.algolia/instantsearch-android/2.7.1/aar)
  - [x] [`2.7.0`](https://search.maven.org/artifact/com.algolia/instantsearch-android/2.7.0/aar)
  - [x] [`2.6.0`](https://search.maven.org/artifact/com.algolia/instantsearch-android/2.6.0/aar)
  
  
 Closes #227