### PR TITLE
fix(subscription): make subscriptions list thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+### Fixed
+- `Subscription`: subscriptions list thread-safety
+
 # 2.8.0
 
 ### Changed

--- a/instantsearch-android-core/src/main/kotlin/com/algolia/instantsearch/core/subscription/Subscription.kt
+++ b/instantsearch-android-core/src/main/kotlin/com/algolia/instantsearch/core/subscription/Subscription.kt
@@ -1,8 +1,10 @@
 package com.algolia.instantsearch.core.subscription
 
+import java.util.concurrent.CopyOnWriteArraySet
+
 public open class Subscription<T> {
 
-    internal val subscriptions: MutableSet<(T) -> Unit> = mutableSetOf()
+    internal val subscriptions: MutableSet<(T) -> Unit> = CopyOnWriteArraySet()
 
     public fun subscribe(subscription: (T) -> Unit) {
         subscriptions += subscription
@@ -22,5 +24,9 @@ public open class Subscription<T> {
 
     public fun unsubscribeAll() {
         subscriptions.clear()
+    }
+
+    public fun notifyAll(value: T) {
+        subscriptions.onEach { it(value) }
     }
 }

--- a/instantsearch-android-core/src/main/kotlin/com/algolia/instantsearch/core/subscription/SubscriptionEvent.kt
+++ b/instantsearch-android-core/src/main/kotlin/com/algolia/instantsearch/core/subscription/SubscriptionEvent.kt
@@ -3,6 +3,6 @@ package com.algolia.instantsearch.core.subscription
 public class SubscriptionEvent<T> : Subscription<T>() {
 
     public fun send(event: T) {
-        subscriptions.forEach { it(event) }
+        notifyAll(event)
     }
 }

--- a/instantsearch-android-core/src/main/kotlin/com/algolia/instantsearch/core/subscription/SubscriptionValue.kt
+++ b/instantsearch-android-core/src/main/kotlin/com/algolia/instantsearch/core/subscription/SubscriptionValue.kt
@@ -5,7 +5,7 @@ import kotlin.properties.Delegates
 public class SubscriptionValue<T>(initialValue: T) : Subscription<T>() {
 
     public var value: T by Delegates.observable(initialValue) { _, _, newValue ->
-        subscriptions.forEach { it(newValue) }
+        notifyAll(newValue)
     }
 
     public fun subscribePast(subscription: (T) -> Unit) {
@@ -14,6 +14,6 @@ public class SubscriptionValue<T>(initialValue: T) : Subscription<T>() {
     }
 
     public fun notifySubscriptions() {
-        subscriptions.forEach { it(value) }
+        notifyAll(value)
     }
 }


### PR DESCRIPTION
`LinkedHashSet` is not thread-safe. Modifying it while iterating over it causes a `ConcurrentModificationException` to be thrown. This can typically happen when subscribing/unsubscribing to a `Subscription` instance while notifying all subscriptions.

`CopyOnWriteArraySet` is useful for the case where the number of elements is generally small and read-only operations vastly outnumber mutative operations. This seems to match our use case here.

_An alternative can be using a mutex._ 