### PR TITLE
feat(paging): add retry functions to paging data source

### DIFF
--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -4,5 +4,5 @@ object Library: Dependency {
 
     override val group = "com.algolia"
     override val artifact = "instantsearch-android"
-    override val version = "2.9.0"
+    override val version = "2.10.0"
 }

--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -4,5 +4,5 @@ object Library: Dependency {
 
     override val group = "com.algolia"
     override val artifact = "instantsearch-android"
-    override val version = "2.10.0"
+    override val version = "2.9.0"
 }

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
@@ -14,9 +14,8 @@ public abstract class RetryablePageKeyedDataSource<Key, Value>(private val retry
     internal var retry: (() -> Any)? = null
 
     public suspend fun retry() {
-        val prevRetry = retry
-        retry = null
-        if (prevRetry != null) {
+        retry?.let { prevRetry ->
+            retry = null
             withContext(retryDispatcher) {
                 prevRetry()
             }
@@ -27,9 +26,8 @@ public abstract class RetryablePageKeyedDataSource<Key, Value>(private val retry
      * Retries the latest call.
      */
     public fun retryAsync() {
-        val prevRetry = retry
-        retry = null
-        if (prevRetry != null) {
+        retry?.let { prevRetry ->
+            retry = null
             retryDispatcher.asExecutor().execute {
                 prevRetry()
             }

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
@@ -1,6 +1,8 @@
 package com.algolia.instantsearch.helper.android.list
 
 import androidx.paging.PageKeyedDataSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * A [PageKeyedDataSource] with retry capability.
@@ -12,9 +14,13 @@ public abstract class RetryablePageKeyedDataSource<Key, Value> : PageKeyedDataSo
     /**
      * Retries the latest call.
      */
-    public fun retry() {
+    public suspend fun retry() {
         val prevRetry = retry
         retry = null
-        prevRetry?.invoke()
+        if (prevRetry != null) {
+            withContext(Dispatchers.IO) {
+                prevRetry()
+            }
+        }
     }
 }

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
@@ -1,0 +1,20 @@
+package com.algolia.instantsearch.helper.android.list
+
+import androidx.paging.PageKeyedDataSource
+
+/**
+ * A [PageKeyedDataSource] with retry capability.
+ */
+public abstract class RetryablePageKeyedDataSource<Key, Value> : PageKeyedDataSource<Key, Value>() {
+
+    internal var retry: (() -> Any)? = null
+
+    /**
+     * Retries the latest call.
+     */
+    public fun retry() {
+        val prevRetry = retry
+        retry = null
+        prevRetry?.invoke()
+    }
+}

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.helper.android.list
 
 import androidx.paging.PageKeyedDataSource
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.withContext
 
 /**
@@ -11,14 +12,24 @@ public abstract class RetryablePageKeyedDataSource<Key, Value> : PageKeyedDataSo
 
     internal var retry: (() -> Any)? = null
 
-    /**
-     * Retries the latest call.
-     */
     public suspend fun retry() {
         val prevRetry = retry
         retry = null
         if (prevRetry != null) {
             withContext(Dispatchers.IO) {
+                prevRetry()
+            }
+        }
+    }
+
+    /**
+     * Retries the latest call.
+     */
+    public fun retryAsync() {
+        val prevRetry = retry
+        retry = null
+        if (prevRetry != null) {
+            Dispatchers.IO.asExecutor().execute {
                 prevRetry()
             }
         }

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/RetryablePageKeyedDataSource.kt
@@ -1,14 +1,15 @@
 package com.algolia.instantsearch.helper.android.list
 
 import androidx.paging.PageKeyedDataSource
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.withContext
 
 /**
  * A [PageKeyedDataSource] with retry capability.
  */
-public abstract class RetryablePageKeyedDataSource<Key, Value> : PageKeyedDataSource<Key, Value>() {
+public abstract class RetryablePageKeyedDataSource<Key, Value>(private val retryDispatcher: CoroutineDispatcher) :
+    PageKeyedDataSource<Key, Value>() {
 
     internal var retry: (() -> Any)? = null
 
@@ -16,7 +17,7 @@ public abstract class RetryablePageKeyedDataSource<Key, Value> : PageKeyedDataSo
         val prevRetry = retry
         retry = null
         if (prevRetry != null) {
-            withContext(Dispatchers.IO) {
+            withContext(retryDispatcher) {
                 prevRetry()
             }
         }
@@ -29,7 +30,7 @@ public abstract class RetryablePageKeyedDataSource<Key, Value> : PageKeyedDataSo
         val prevRetry = retry
         retry = null
         if (prevRetry != null) {
-            Dispatchers.IO.asExecutor().execute {
+            retryDispatcher.asExecutor().execute {
                 prevRetry()
             }
         }

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherMultipleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherMultipleIndexDataSource.kt
@@ -13,25 +13,25 @@ public class SearcherMultipleIndexDataSource<T>(
     private val searcher: SearcherMultipleIndex,
     private val indexQuery: IndexQuery,
     private val triggerSearchForQueries: ((List<IndexQuery>) -> Boolean) = { true },
-    private val transformer: (ResponseSearch.Hit) -> T,
     retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val transformer: (ResponseSearch.Hit) -> T,
 ) : RetryablePageKeyedDataSource<Int, T>(retryDispatcher) {
 
     public class Factory<T>(
         private val searcher: SearcherMultipleIndex,
         private val indexQuery: IndexQuery,
         private val triggerSearchForQueries: ((List<IndexQuery>) -> Boolean) = { true },
-        private val transformer: (ResponseSearch.Hit) -> T,
         private val retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
+        private val transformer: (ResponseSearch.Hit) -> T,
     ) : DataSource.Factory<Int, T>() {
 
         override fun create(): DataSource<Int, T> {
             return SearcherMultipleIndexDataSource(
-                searcher,
-                indexQuery,
-                triggerSearchForQueries,
-                transformer,
-                retryDispatcher
+                searcher = searcher,
+                indexQuery = indexQuery,
+                triggerSearchForQueries = triggerSearchForQueries,
+                transformer = transformer,
+                retryDispatcher = retryDispatcher
             )
         }
     }

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherMultipleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherMultipleIndexDataSource.kt
@@ -1,10 +1,11 @@
 package com.algolia.instantsearch.helper.android.list
 
 import androidx.paging.DataSource
-import androidx.paging.PageKeyedDataSource
 import com.algolia.instantsearch.helper.searcher.SearcherMultipleIndex
 import com.algolia.search.model.multipleindex.IndexQuery
 import com.algolia.search.model.response.ResponseSearch
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
@@ -13,17 +14,25 @@ public class SearcherMultipleIndexDataSource<T>(
     private val indexQuery: IndexQuery,
     private val triggerSearchForQueries: ((List<IndexQuery>) -> Boolean) = { true },
     private val transformer: (ResponseSearch.Hit) -> T,
-) : RetryablePageKeyedDataSource<Int, T>() {
+    retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : RetryablePageKeyedDataSource<Int, T>(retryDispatcher) {
 
     public class Factory<T>(
         private val searcher: SearcherMultipleIndex,
         private val indexQuery: IndexQuery,
         private val triggerSearchForQueries: ((List<IndexQuery>) -> Boolean) = { true },
         private val transformer: (ResponseSearch.Hit) -> T,
+        private val retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
     ) : DataSource.Factory<Int, T>() {
 
         override fun create(): DataSource<Int, T> {
-            return SearcherMultipleIndexDataSource(searcher, indexQuery, triggerSearchForQueries, transformer)
+            return SearcherMultipleIndexDataSource(
+                searcher,
+                indexQuery,
+                triggerSearchForQueries,
+                transformer,
+                retryDispatcher
+            )
         }
     }
 

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -12,19 +12,24 @@ import kotlinx.coroutines.withContext
 public class SearcherSingleIndexDataSource<T>(
     private val searcher: SearcherSingleIndex,
     private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
-    private val transformer: (ResponseSearch.Hit) -> T,
     retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val transformer: (ResponseSearch.Hit) -> T,
 ) : RetryablePageKeyedDataSource<Int, T>(retryDispatcher) {
 
     public class Factory<T>(
         private val searcher: SearcherSingleIndex,
         private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
+        private val retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
         private val transformer: (ResponseSearch.Hit) -> T,
-        private val retryDispatcher: CoroutineDispatcher = Dispatchers.IO
     ) : DataSource.Factory<Int, T>() {
 
         override fun create(): DataSource<Int, T> {
-            return SearcherSingleIndexDataSource(searcher, triggerSearchForQuery, transformer, retryDispatcher)
+            return SearcherSingleIndexDataSource(
+                searcher = searcher,
+                triggerSearchForQuery = triggerSearchForQuery,
+                retryDispatcher = retryDispatcher,
+                transformer = transformer
+            )
         }
     }
 

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -4,6 +4,8 @@ import androidx.paging.DataSource
 import com.algolia.instantsearch.helper.searcher.SearcherSingleIndex
 import com.algolia.search.model.response.ResponseSearch
 import com.algolia.search.model.search.Query
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
@@ -11,16 +13,18 @@ public class SearcherSingleIndexDataSource<T>(
     private val searcher: SearcherSingleIndex,
     private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
     private val transformer: (ResponseSearch.Hit) -> T,
-) : RetryablePageKeyedDataSource<Int, T>() {
+    retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : RetryablePageKeyedDataSource<Int, T>(retryDispatcher) {
 
     public class Factory<T>(
         private val searcher: SearcherSingleIndex,
         private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
         private val transformer: (ResponseSearch.Hit) -> T,
+        private val retryDispatcher: CoroutineDispatcher = Dispatchers.IO
     ) : DataSource.Factory<Int, T>() {
 
         override fun create(): DataSource<Int, T> {
-            return SearcherSingleIndexDataSource(searcher, triggerSearchForQuery, transformer)
+            return SearcherSingleIndexDataSource(searcher, triggerSearchForQuery, transformer, retryDispatcher)
         }
     }
 


### PR DESCRIPTION
Add two functions to data source to retry the latest failed `loadInitial` or `loadAfter` operation:
* `retry`: takes advantage of a `CoroutineScope` and a `CoroutineDispatcher` (uses `Dispatchers.IO` by default)
*  `retryAsync`: uses a `CoroutineDispatcher` as an `Executor`