### PR TITLE
[+] fixing totalCount value in onResult callback by passing the actua…

### DIFF
--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -49,7 +49,7 @@ public class SearcherSingleIndexDataSource<T>(
                 if (queryLoaded != searcher.query.query) {
                     invalidate()
                 }
-                val nextKey = if (response.nbHits > initialLoadSize) 1 else null
+                val nextKey = if (response.hits.size > initialLoadSize) 1 else null
 
                 withContext(searcher.coroutineScope.coroutineContext) {
                     searcher.response.value = response

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -56,7 +56,7 @@ public class SearcherSingleIndexDataSource<T>(
                     searcher.isLoading.value = false
                 }
                 retry = null
-                callback.onResult(response.hits.map(transformer), 0, response.nbHits, null, nextKey)
+                callback.onResult(response.hits.map(transformer), 0, response.hits.size, null, nextKey)
             } catch (throwable: Throwable) {
                 retry = { loadInitial(params, callback) }
                 resultError(throwable)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information
so that others can review your pull request. -->

# Summary
we are using algolia instant search and pagination with different indexes and some of them are sorted, I have noticed a weird  behaviour in the RecyclerView that shows the results, when searching inside the default index without sorting it works perfect but when changing to search inside a sorted index the RecyclerView started to duplicated some results and returning the wrong size, so I started debugging to figure out why does it return wring size different than the actual data list size

# Result
after tracking down the issue I landed into this class `SearcherSingleIndexDataSource.kt `which handles the paginated results and found this callback `callback.onResult(response.hits.map(transformer), 0, response.nbHits, null, nextKey) ` and by debugging `response.nbHits ` i noticed that it returns always the matches count for a searchable query and that's not the case when searching inside a sorted index the exact list size will be `nbSortedHits ` and in either cases we should use the actual hits size no matter it's sorted or not so I replaced  `response.nbHits` with `response.hits.size` and the RecyclerView started to work perfectly again with all my indices, the final replaced callback was `callback.onResult(response.hits.map(transformer), 0, response.hits.size, null, nextKey)`
