### PR TITLE
Feature/control search for empty query

### DIFF
--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -49,7 +49,7 @@ public class SearcherSingleIndexDataSource<T>(
                 if (queryLoaded != searcher.query.query) {
                     invalidate()
                 }
-                val nextKey = if (response.nbHits > initialLoadSize) 1 else null
+                val nextKey = if (response.hits.size > initialLoadSize) 1 else null
 
                 withContext(searcher.coroutineScope.coroutineContext) {
                     searcher.response.value = response

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -11,14 +11,14 @@ import kotlinx.coroutines.withContext
 
 public class SearcherSingleIndexDataSource<T>(
     private val searcher: SearcherSingleIndex,
-    private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
+    private val emptyQuerySearchEnabled:  Boolean =  true ,
     retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val transformer: (ResponseSearch.Hit) -> T,
 ) : RetryablePageKeyedDataSource<Int, T>(retryDispatcher) {
 
     public class Factory<T>(
         private val searcher: SearcherSingleIndex,
-        private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
+        private val emptyQuerySearchEnabled:  Boolean =  true,
         private val retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
         private val transformer: (ResponseSearch.Hit) -> T,
     ) : DataSource.Factory<Int, T>() {
@@ -26,7 +26,7 @@ public class SearcherSingleIndexDataSource<T>(
         override fun create(): DataSource<Int, T> {
             return SearcherSingleIndexDataSource(
                 searcher = searcher,
-                triggerSearchForQuery = triggerSearchForQuery,
+                emptyQuerySearchEnabled = emptyQuerySearchEnabled,
                 retryDispatcher = retryDispatcher,
                 transformer = transformer
             )
@@ -37,7 +37,7 @@ public class SearcherSingleIndexDataSource<T>(
 
     override fun loadInitial(params: LoadInitialParams<Int>, callback: LoadInitialCallback<Int, T>) {
         val queryLoaded = searcher.query.query
-        if (!triggerSearchForQuery(searcher.query)) return
+        if (!emptyQuerySearchEnabled && queryLoaded.isNullOrEmpty()) return
 
         initialLoadSize = params.requestedLoadSize
         searcher.query.hitsPerPage = initialLoadSize

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.withContext
 public class SearcherSingleIndexDataSource<T>(
     private val searcher: SearcherSingleIndex,
     private val emptyQuerySearchEnabled:  Boolean =  true ,
-    private val triggerSearchForQuery: ((Query) -> Boolean),
+    private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
     retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val transformer: (ResponseSearch.Hit) -> T,
 ) : RetryablePageKeyedDataSource<Int, T>(retryDispatcher) {
@@ -20,7 +20,7 @@ public class SearcherSingleIndexDataSource<T>(
     public class Factory<T>(
         private val searcher: SearcherSingleIndex,
         private val emptyQuerySearchEnabled:  Boolean =  true,
-        private val triggerSearchForQuery: ((Query) -> Boolean),
+        private val triggerSearchForQuery: ((Query) -> Boolean) = { true },
         private val retryDispatcher: CoroutineDispatcher = Dispatchers.IO,
         private val transformer: (ResponseSearch.Hit) -> T,
     ) : DataSource.Factory<Int, T>() {

--- a/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
+++ b/instantsearch-android/src/main/java/com/algolia/instantsearch/helper/android/list/SearcherSingleIndexDataSource.kt
@@ -56,7 +56,7 @@ public class SearcherSingleIndexDataSource<T>(
                     searcher.isLoading.value = false
                 }
                 retry = null
-                callback.onResult(response.hits.map(transformer), 0, response.nbHits, null, nextKey)
+                callback.onResult(response.hits.map(transformer), 0, response.hits.size, null, nextKey)
             } catch (throwable: Throwable) {
                 retry = { loadInitial(params, callback) }
                 resultError(throwable)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information
so that others can review your pull request. -->

# Summary
I was trying to disable searching when a search query is an empty string , I tried to override the listener for searchView and there is no luck and after digging around I found that the search results loaded when `SearcherSingleIndexDataSource.Factory` initialized and the engine default query is an empty string

# Result
so I decided to do a little change to `SearcherSingleIndexDataSource.kt` and add a Boolean variable to enable searching for empty queries or not at the initialization of that class, the variable called `emptyQuerySearchEnabled` and its default value is true and when changing to false the search will only be triggered when search query not empty, u can use it as follow :
```
SearcherSingleIndexDataSource.Factory(searcher, false) { hit ->
        
    }
```