### PR TITLE
refactor(paging): mark paginator as experimental

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,12 +29,12 @@ androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "s
 google-material = { group = "com.google.android.material", name = "material", version = "1.4.0" }
 
 # test
-test-androidx-ext = { group = "androidx.test.ext", name = "junit", version = "1.1.1" }
-test-androidx-runner = { group = "androidx.test", name = "runner", version = "1.2.0" }
+test-androidx-ext = { group = "androidx.test.ext", name = "junit", version = "1.1.3" }
+test-androidx-runner = { group = "androidx.test", name = "runner", version = "1.4.0" }
 test-androidx-espresso = { group = "androidx.test.espresso", name = "espresso", version = "3.2.0" }
 test-androidx-work = { group = "androidx.work", name = "work-testing", version.ref = "work" }
-test-robolectric = { group = "org.robolectric", name = "robolectric", version = "4.5.1" }
-test-mockk = { group = "io.mockk", name = "mockk", version = "1.10.6" }
+test-robolectric = { group = "org.robolectric", name = "robolectric", version = "4.6.1" }
+test-mockk = { group = "io.mockk", name = "mockk", version = "1.12.0" }
 test-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 test-ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 algolia-client = "1.9.2"
 compose = "1.0.1"
-paging-compose = "1.0.0-alpha12"
+paging-compose = "1.0.0-alpha13"
 coroutines = "1.5.0-native-mt"
 ktor = "1.6.2"
 work = "2.5.0"

--- a/instantsearch-compose/build.gradle.kts
+++ b/instantsearch-compose/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 31
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 30
+        targetSdk = 31
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/filter/facet/FacetListConnector.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/filter/facet/FacetListConnector.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.compose.filter.facet
 
 import com.algolia.instantsearch.compose.filter.facet.internal.FacetListConnectionPager
 import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.helper.filter.facet.FacetListConnector
 import com.algolia.instantsearch.helper.filter.facet.FacetListViewModel
@@ -11,6 +12,7 @@ import com.algolia.instantsearch.helper.filter.facet.FacetListViewModel
  *
  * @param paginator paginator to be connected
  */
+@ExperimentalInstantSearch
 public fun <T : Any> FacetListConnector.connectPaginator(paginator: Paginator<T>): Connection {
     return viewModel.connectPaginator(paginator)
 }
@@ -20,6 +22,7 @@ public fun <T : Any> FacetListConnector.connectPaginator(paginator: Paginator<T>
  *
  * @param paginator paginator to be connected
  */
+@ExperimentalInstantSearch
 public fun <T : Any> FacetListViewModel.connectPaginator(paginator: Paginator<T>): Connection {
     return FacetListConnectionPager(this, paginator)
 }

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/filter/facet/internal/FacetListConnectionPager.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/filter/facet/internal/FacetListConnectionPager.kt
@@ -1,6 +1,7 @@
 package com.algolia.instantsearch.compose.filter.facet.internal
 
 import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.helper.filter.facet.FacetListViewModel
 import com.algolia.search.model.search.Facet
@@ -11,6 +12,7 @@ import com.algolia.search.model.search.Facet
  * @param facetListViewModel facet list view model handling selections
  * @param paginator component handling Paged data
  */
+@ExperimentalInstantSearch
 internal class FacetListConnectionPager<T : Any>(
     private val facetListViewModel: FacetListViewModel,
     private val paginator: Paginator<T>

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/filter/state/FilterStateConnection.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/filter/state/FilterStateConnection.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.compose.filter.state
 
 import com.algolia.instantsearch.compose.filter.state.internal.FilterStateConnectionPaginator
 import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.helper.filter.state.FilterState
 
@@ -10,6 +11,7 @@ import com.algolia.instantsearch.helper.filter.state.FilterState
  *
  * @param paginator paginator to be connected
  */
+@ExperimentalInstantSearch
 public fun <T : Any> FilterState.connectPaginator(paginator: Paginator<T>): Connection {
     return FilterStateConnectionPaginator(paginator, this)
 }

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/filter/state/internal/FilterStateConnectionPaginator.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/filter/state/internal/FilterStateConnectionPaginator.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.compose.filter.state.internal
 
 import com.algolia.instantsearch.compose.list.Paginator
 import com.algolia.instantsearch.core.Callback
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.helper.filter.state.FilterState
 import com.algolia.instantsearch.helper.filter.state.Filters
@@ -12,6 +13,7 @@ import com.algolia.instantsearch.helper.filter.state.Filters
  * @param paginator PagingData handler to connect
  * @param filterState FilterState to connect
  */
+@ExperimentalInstantSearch
 internal data class FilterStateConnectionPaginator<T : Any>(
     private val paginator: Paginator<T>,
     private val filterState: FilterState,

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/list/Paginator.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/list/Paginator.kt
@@ -7,6 +7,7 @@ import androidx.paging.PagingData
 import com.algolia.instantsearch.compose.list.internal.SearcherMultipleIndexPagingSource
 import com.algolia.instantsearch.compose.list.internal.SearcherPaginator
 import com.algolia.instantsearch.compose.list.internal.SearcherSingleIndexPagingSource
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.helper.searcher.SearcherMultipleIndex
 import com.algolia.instantsearch.helper.searcher.SearcherSingleIndex
 import com.algolia.search.model.multipleindex.IndexQuery
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Component handling [PagingData].
  */
+@ExperimentalInstantSearch
 public interface Paginator<T : Any> {
 
     /**
@@ -36,6 +38,7 @@ public interface Paginator<T : Any> {
  * @param pagingConfig configure loading behavior within a Pager
  * @param transformer mapping applied to search responses
  */
+@ExperimentalInstantSearch
 public fun <T : Any> Paginator(
     searcher: SearcherSingleIndex,
     pagingConfig: PagingConfig = PagingConfig(pageSize = 10),
@@ -53,6 +56,7 @@ public fun <T : Any> Paginator(
  * @param pagingConfig configure loading behavior within a Pager
  * @param transformer mapping applied to search responses
  */
+@ExperimentalInstantSearch
 public fun <T : Any> Paginator(
     searcher: SearcherMultipleIndex,
     indexQuery: IndexQuery,

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/list/internal/SearcherMultipleIndexPagingSource.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/list/internal/SearcherMultipleIndexPagingSource.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.compose.list.internal
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.helper.searcher.SearcherMultipleIndex
 import com.algolia.search.model.multipleindex.IndexQuery
 import com.algolia.search.model.response.ResponseSearch
@@ -15,6 +16,7 @@ import kotlinx.coroutines.withContext
  * @param indexQuery query associated to a specific index
  * @param transformer mapping applied to search responses
  */
+@ExperimentalInstantSearch
 internal class SearcherMultipleIndexPagingSource<T : Any>(
     private val searcher: SearcherMultipleIndex,
     private val indexQuery: IndexQuery,

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/list/internal/SearcherPaginator.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/list/internal/SearcherPaginator.kt
@@ -5,6 +5,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
 import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 
 /**
  * [Paginator] implementation for Searcher.
@@ -12,6 +13,7 @@ import com.algolia.instantsearch.compose.list.Paginator
  * @param pagingConfig configure loading behavior within a Pager
  * @param pagingSourceFactory searcher paging source factory
  */
+@ExperimentalInstantSearch
 internal class SearcherPaginator<T : Any>(
     pagingConfig: PagingConfig = PagingConfig(pageSize = 10),
     pagingSourceFactory: () -> PagingSource<Int, T>

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/list/internal/SearcherSingleIndexPagingSource.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/list/internal/SearcherSingleIndexPagingSource.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.compose.list.internal
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.helper.searcher.SearcherSingleIndex
 import com.algolia.search.model.response.ResponseSearch
 import kotlinx.coroutines.withContext
@@ -12,6 +13,7 @@ import kotlinx.coroutines.withContext
  * @param searcher single index searcher
  * @param transformer mapping applied to search responses
  */
+@ExperimentalInstantSearch
 internal class SearcherSingleIndexPagingSource<T : Any>(
     private val searcher: SearcherSingleIndex,
     private val transformer: (ResponseSearch.Hit) -> T

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/searchbox/SearchBoxConnector.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/searchbox/SearchBoxConnector.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.compose.searchbox
 
 import com.algolia.instantsearch.compose.list.Paginator
 import com.algolia.instantsearch.compose.searchbox.internal.SearchBoxConnectionPaginator
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.core.searchbox.SearchBoxViewModel
 import com.algolia.instantsearch.helper.searchbox.SearchBoxConnector
@@ -12,6 +13,7 @@ import com.algolia.instantsearch.helper.searchbox.SearchMode
  *
  * @param paginator paginator to be connected
  */
+@ExperimentalInstantSearch
 public fun <R, T : Any> SearchBoxConnector<R>.connectPaginator(paginator: Paginator<T>): Connection {
     return viewModel.connectPaginator(paginator, searchMode)
 }
@@ -21,6 +23,7 @@ public fun <R, T : Any> SearchBoxConnector<R>.connectPaginator(paginator: Pagina
  *
  * @param paginator paginator to be connected
  */
+@ExperimentalInstantSearch
 public fun <T : Any> SearchBoxViewModel.connectPaginator(
     paginator: Paginator<T>,
     searchMode: SearchMode = SearchMode.AsYouType

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/searchbox/internal/SearchBoxConnectionPaginator.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/searchbox/internal/SearchBoxConnectionPaginator.kt
@@ -1,6 +1,7 @@
 package com.algolia.instantsearch.compose.searchbox.internal
 
 import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.core.searchbox.SearchBoxViewModel
 import com.algolia.instantsearch.helper.searchbox.SearchMode
@@ -12,6 +13,7 @@ import com.algolia.instantsearch.helper.searchbox.SearchMode
  * @param paginator component handling Paged data
  * @param searchMode selected search mode
  */
+@ExperimentalInstantSearch
 internal class SearchBoxConnectionPaginator<T : Any>(
     private val viewModel: SearchBoxViewModel,
     private val paginator: Paginator<T>,

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/sortby/SortByConnection.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/sortby/SortByConnection.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.compose.sortby
 
 import com.algolia.instantsearch.compose.list.Paginator
 import com.algolia.instantsearch.compose.sortby.internal.SortByConnectionPaginator
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.helper.sortby.SortByConnector
 import com.algolia.instantsearch.helper.sortby.SortByViewModel
@@ -11,6 +12,7 @@ import com.algolia.instantsearch.helper.sortby.SortByViewModel
  *
  * @param paginator paginator to be connected
  */
+@ExperimentalInstantSearch
 public fun <T : Any> SortByViewModel.connectPagedList(paginator: Paginator<T>): Connection {
     return SortByConnectionPaginator(this, paginator)
 }
@@ -20,6 +22,7 @@ public fun <T : Any> SortByViewModel.connectPagedList(paginator: Paginator<T>): 
  *
  * @param paginator paginator to be connected
  */
+@ExperimentalInstantSearch
 public fun <T : Any> SortByConnector.connectPagedList(paginator: Paginator<T>): Connection {
     return viewModel.connectPagedList(paginator)
 }

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/sortby/internal/SortByConnectionPaginator.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/sortby/internal/SortByConnectionPaginator.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.compose.sortby.internal
 
 import com.algolia.instantsearch.compose.list.Paginator
 import com.algolia.instantsearch.core.Callback
+import com.algolia.instantsearch.core.ExperimentalInstantSearch
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.helper.sortby.SortByViewModel
 
@@ -11,6 +12,7 @@ import com.algolia.instantsearch.helper.sortby.SortByViewModel
  * @param viewModel SortBy ViewModel to connect
  * @param paginator PagingData handler to connect
  */
+@ExperimentalInstantSearch
 internal class SortByConnectionPaginator<T : Any>(
     private val viewModel: SortByViewModel,
     private val paginator: Paginator<T>,

--- a/instantsearch-insights/build.gradle.kts
+++ b/instantsearch-insights/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 31
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 30
+        targetSdk = 31
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/instantsearch/build.gradle.kts
+++ b/instantsearch/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 31
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 30
+        targetSdk = 31
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
since it based on paging-compose alpha versions

| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no

## Describe your change

The [paging-compose](https://developer.android.com/jetpack/androidx/releases/paging#paging_compose_version_100_2) library is still in alpha stage; we are marking the APIs depending on it as `@ExperimentalInstantSearch`.