### PR TITLE
chore: update workmanager to `2.7.0`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ compose = "1.0.1"
 paging-compose = "1.0.0-alpha13"
 coroutines = "1.5.0-native-mt"
 ktor = "1.6.2"
-work = "2.5.0"
+work = "2.7.0"
 
 [libraries]
 # network


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Update workmanagerto version `2.7.0` to fix errors related to Android 12 [foreground services restrictions](https://developer.android.com/guide/components/foreground-services#background-start-restrictions).
