### PR TITLE
refactor: rename `Internal` annotation to `InternalInstantSearch`

### DIFF
--- a/instantsearch-core/build.gradle.kts
+++ b/instantsearch-core/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
         all {
             languageSettings {
                 optIn("kotlin.RequiresOptIn")
-                optIn("com.algolia.instantsearch.Internal")
+                optIn("com.algolia.instantsearch.InternalInstantSearch")
                 optIn("com.algolia.instantsearch.ExperimentalInstantSearch")
             }
         }

--- a/instantsearch-utils/src/commonMain/kotlin/com/algolia/instantsearch/Annotations.kt
+++ b/instantsearch-utils/src/commonMain/kotlin/com/algolia/instantsearch/Annotations.kt
@@ -42,4 +42,4 @@ public annotation class ExperimentalInstantSearch
     level = RequiresOptIn.Level.ERROR,
     message = "This API is internal in InstantSearch and should not be used. It could be removed or changed without notice."
 )
-public annotation class Internal
+public annotation class InternalInstantSearch

--- a/instantsearch-utils/src/commonMain/kotlin/com/algolia/instantsearch/encode/Gzip.kt
+++ b/instantsearch-utils/src/commonMain/kotlin/com/algolia/instantsearch/encode/Gzip.kt
@@ -1,9 +1,9 @@
 package com.algolia.instantsearch.encode
 
-import com.algolia.instantsearch.Internal
+import com.algolia.instantsearch.InternalInstantSearch
 
 /**
  * Applies GZIP compression to a [ByteArray]
  */
-@Internal
+@InternalInstantSearch
 public expect fun ByteArray.gzip(): ByteArray

--- a/instantsearch/build.gradle.kts
+++ b/instantsearch/build.gradle.kts
@@ -55,7 +55,7 @@ kotlin {
         all {
             languageSettings {
                 optIn("kotlin.RequiresOptIn")
-                optIn("com.algolia.instantsearch.Internal")
+                optIn("com.algolia.instantsearch.InternalInstantSearch")
                 optIn("com.algolia.instantsearch.ExperimentalInstantSearch")
                 optIn("com.algolia.search.ExperimentalAlgoliaClientAPI")
                 optIn("kotlinx.coroutines.ExperimentalCoroutinesApi")

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/helper/extension/Telemetry.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/helper/extension/Telemetry.kt
@@ -1,9 +1,9 @@
-@file:OptIn(Internal::class, ExperimentalInstantSearch::class, ExperimentalStdlibApi::class)
+@file:OptIn(InternalInstantSearch::class, ExperimentalInstantSearch::class, ExperimentalStdlibApi::class)
 
 package com.algolia.instantsearch.helper.extension
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.Internal
+import com.algolia.instantsearch.InternalInstantSearch
 import com.algolia.instantsearch.core.selectable.list.SelectionMode
 import com.algolia.instantsearch.encode.gzip
 import com.algolia.instantsearch.helper.filter.clear.ClearMode
@@ -38,7 +38,6 @@ import com.algolia.search.model.Attribute
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.multipleindex.MultipleQueriesStrategy
 import com.algolia.search.model.search.Facet
-import io.ktor.util.InternalAPI
 import io.ktor.util.encodeBase64
 
 /** Get telemetry schema header **/
@@ -47,7 +46,7 @@ internal fun telemetrySchema(): String? {
 }
 
 /** Compress [Schema] structure (gzip + base64) */
-@OptIn(InternalAPI::class)
+@OptIn(io.ktor.util.InternalAPI::class)
 private fun Schema.compress(): String {
     return toByteArray().gzip().encodeBase64() // TODO: replace ktor's encodeBase64
 }

--- a/instantsearch/src/commonTest/kotlin/telemetry/TestTelemetry.kt
+++ b/instantsearch/src/commonTest/kotlin/telemetry/TestTelemetry.kt
@@ -1,7 +1,7 @@
 package telemetry
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.Internal
+import com.algolia.instantsearch.InternalInstantSearch
 import com.algolia.instantsearch.core.hits.connectHitsView
 import com.algolia.instantsearch.core.loading.LoadingViewModel
 import com.algolia.instantsearch.core.number.NumberViewModel
@@ -57,11 +57,11 @@ import mockClient
 import relatedItems.SimpleProduct
 import relatedItems.mockHitsView
 
-@OptIn(ExperimentalInstantSearch::class, Internal::class)
+@OptIn(ExperimentalInstantSearch::class, InternalInstantSearch::class)
 class TestTelemetry { // instrumented because it uses android's Base64
 
     val client = mockClient()
-    val indexName = IndexName("myIndex")
+    val indexName = ComponentParam.IndexName("myIndex")
 
     val filterState = FilterState()
     val searcherSingleIndex = SearcherSingleIndex(client.initIndex(indexName), isDisjunctiveFacetingEnabled = false)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no
