### PR TITLE
feat: androidx paging 3 support

### DIFF
--- a/extensions/android-paging3/build.gradle.kts
+++ b/extensions/android-paging3/build.gradle.kts
@@ -47,6 +47,6 @@ android {
 dependencies {
     api(project(":instantsearch"))
     api(project(":instantsearch-utils"))
-    api(libs.androidx.paging.common)
+    api(libs.androidx.paging3.common)
     testImplementation(kotlin("test-junit"))
 }

--- a/extensions/android-paging3/build.gradle.kts
+++ b/extensions/android-paging3/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+    id("com.vanniktech.maven.publish")
+}
+
+android {
+    compileSdk = 31
+
+    defaultConfig {
+        minSdk = 21
+        targetSdk = 31
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        getByName("release"){
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        freeCompilerArgs += listOf(
+            "-Xopt-in=kotlin.RequiresOptIn",
+            "-Xexplicit-api=strict"
+        )
+    }
+
+    buildFeatures {
+        buildConfig = false
+    }
+
+    testOptions.unitTests.apply {
+        isIncludeAndroidResources = true
+        isReturnDefaultValues = true
+    }
+}
+
+
+dependencies {
+    api(project(":instantsearch"))
+    api(project(":instantsearch-utils"))
+    api(libs.androidx.paging.common)
+    testImplementation(kotlin("test-junit"))
+}

--- a/extensions/android-paging3/gradle.properties
+++ b/extensions/android-paging3/gradle.properties
@@ -1,0 +1,2 @@
+POM_NAME=InstantSearch Android Paging3 Extension
+POM_ARTIFACT_ID=instantsearch-android-paging3

--- a/extensions/android-paging3/src/main/AndroidManifest.xml
+++ b/extensions/android-paging3/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.algolia.instantsearch.android.paging3" />

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/Paginator.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/Paginator.kt
@@ -1,12 +1,12 @@
 @file:Suppress("FunctionName")
 
-package com.algolia.instantsearch.compose.list
+package com.algolia.instantsearch.android.paging3
 
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.list.internal.SearcherPaginator
-import com.algolia.instantsearch.compose.list.internal.SearcherPagingSource
+import com.algolia.instantsearch.android.paging3.internal.SearcherPaginator
+import com.algolia.instantsearch.android.paging3.internal.SearcherPagingSource
 import com.algolia.instantsearch.helper.searcher.util.SearcherForHits
 import com.algolia.search.model.params.SearchParameters
 import com.algolia.search.model.response.ResponseSearch

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/Paginator.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/Paginator.kt
@@ -4,7 +4,6 @@ package com.algolia.instantsearch.android.paging3
 
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
-import com.algolia.instantsearch.ExperimentalInstantSearch
 import com.algolia.instantsearch.android.paging3.internal.SearcherPaginator
 import com.algolia.instantsearch.android.paging3.internal.SearcherPagingSource
 import com.algolia.instantsearch.helper.searcher.util.SearcherForHits
@@ -15,7 +14,6 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Component handling [PagingData].
  */
-@ExperimentalInstantSearch
 public interface Paginator<T : Any> {
 
     /**
@@ -36,7 +34,6 @@ public interface Paginator<T : Any> {
  * @param pagingConfig configure loading behavior within a Pager
  * @param transformer mapping applied to search responses
  */
-@ExperimentalInstantSearch
 public fun <T : Any> Paginator(
     searcher: SearcherForHits<out SearchParameters>,
     pagingConfig: PagingConfig = PagingConfig(pageSize = 10),

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/facet/FacetListConnector.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/facet/FacetListConnector.kt
@@ -1,8 +1,8 @@
-package com.algolia.instantsearch.compose.filter.facet
+package com.algolia.instantsearch.android.paging3.facet
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.filter.facet.internal.FacetListConnectionPager
-import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.android.paging3.Paginator
+import com.algolia.instantsearch.android.paging3.facet.internal.FacetListConnectionPager
 import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.helper.filter.facet.FacetListConnector
 import com.algolia.instantsearch.helper.filter.facet.FacetListViewModel

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/facet/internal/FacetListConnectionPager.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/facet/internal/FacetListConnectionPager.kt
@@ -1,7 +1,7 @@
-package com.algolia.instantsearch.compose.filter.facet.internal
+package com.algolia.instantsearch.android.paging3.facet.internal
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.android.paging3.Paginator
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.helper.filter.facet.FacetListViewModel
 import com.algolia.search.model.search.Facet

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/filterstate/FilterStateConnection.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/filterstate/FilterStateConnection.kt
@@ -1,8 +1,8 @@
-package com.algolia.instantsearch.compose.filter.state
+package com.algolia.instantsearch.android.paging3.filterstate
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.filter.state.internal.FilterStateConnectionPaginator
-import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.android.paging3.Paginator
+import com.algolia.instantsearch.android.paging3.filterstate.internal.FilterStateConnectionPaginator
 import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.helper.filter.state.FilterState
 

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/filterstate/internal/FilterStateConnectionPaginator.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/filterstate/internal/FilterStateConnectionPaginator.kt
@@ -1,7 +1,7 @@
-package com.algolia.instantsearch.compose.filter.state.internal
+package com.algolia.instantsearch.android.paging3.filterstate.internal
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.android.paging3.Paginator
 import com.algolia.instantsearch.core.Callback
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.helper.filter.state.FilterState

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/internal/SearcherPaginator.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/internal/SearcherPaginator.kt
@@ -1,11 +1,11 @@
-package com.algolia.instantsearch.compose.list.internal
+package com.algolia.instantsearch.android.paging3.internal
 
 import androidx.paging.InvalidatingPagingSourceFactory
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.android.paging3.Paginator
 
 /**
  * [Paginator] implementation for Searcher.

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/internal/SearcherPaginator.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/internal/SearcherPaginator.kt
@@ -13,7 +13,6 @@ import com.algolia.instantsearch.android.paging3.Paginator
  * @param pagingConfig configure loading behavior within a Pager
  * @param pagingSourceFactory searcher paging source factory
  */
-@ExperimentalInstantSearch
 internal class SearcherPaginator<T : Any>(
     pagingConfig: PagingConfig = PagingConfig(pageSize = 10),
     pagingSourceFactory: () -> PagingSource<Int, T>

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/internal/SearcherPagingSource.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/internal/SearcherPagingSource.kt
@@ -1,8 +1,7 @@
-package com.algolia.instantsearch.compose.list.internal
+package com.algolia.instantsearch.android.paging3.internal
 
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
-import com.algolia.instantsearch.ExperimentalInstantSearch
 import com.algolia.instantsearch.helper.searcher.util.SearcherForHits
 import com.algolia.search.model.params.SearchParameters
 import com.algolia.search.model.response.ResponseSearch
@@ -14,7 +13,6 @@ import kotlinx.coroutines.withContext
  * @param searcher single index searcher
  * @param transformer mapping applied to search responses
  */
-@ExperimentalInstantSearch
 internal class SearcherPagingSource<T : Any>(
     private val searcher: SearcherForHits<out SearchParameters>,
     private val transformer: (ResponseSearch.Hit) -> T

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/searchbox/SearchBoxConnection.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/searchbox/SearchBoxConnection.kt
@@ -1,4 +1,4 @@
-package com.algolia.instantsearch.compose.searchbox
+package com.algolia.instantsearch.android.paging3.searchbox
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
 import com.algolia.instantsearch.android.paging3.Paginator

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/searchbox/SearchBoxConnection.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/searchbox/SearchBoxConnection.kt
@@ -1,8 +1,8 @@
 package com.algolia.instantsearch.compose.searchbox
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.list.Paginator
-import com.algolia.instantsearch.compose.searchbox.internal.SearchBoxConnectionPaginator
+import com.algolia.instantsearch.android.paging3.Paginator
+import com.algolia.instantsearch.android.paging3.searchbox.internal.SearchBoxConnectionPaginator
 import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.core.searchbox.SearchBoxViewModel
 import com.algolia.instantsearch.helper.searchbox.SearchBoxConnector

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/searchbox/internal/SearchBoxConnectionPaginator.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/searchbox/internal/SearchBoxConnectionPaginator.kt
@@ -1,7 +1,7 @@
-package com.algolia.instantsearch.compose.searchbox.internal
+package com.algolia.instantsearch.android.paging3.searchbox.internal
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.android.paging3.Paginator
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.core.searchbox.SearchBoxViewModel
 import com.algolia.instantsearch.helper.searchbox.SearchMode

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/sortby/SortByConnection.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/sortby/SortByConnection.kt
@@ -1,8 +1,8 @@
-package com.algolia.instantsearch.compose.sortby
+package com.algolia.instantsearch.android.paging3.sortby
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.list.Paginator
-import com.algolia.instantsearch.compose.sortby.internal.SortByConnectionPaginator
+import com.algolia.instantsearch.android.paging3.Paginator
+import com.algolia.instantsearch.android.paging3.sortby.internal.SortByConnectionPaginator
 import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.core.searcher.Searcher
 import com.algolia.instantsearch.helper.searcher.IndexNameHolder

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/sortby/SortByConnection.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/sortby/SortByConnection.kt
@@ -1,6 +1,5 @@
 package com.algolia.instantsearch.android.paging3.sortby
 
-import com.algolia.instantsearch.ExperimentalInstantSearch
 import com.algolia.instantsearch.android.paging3.Paginator
 import com.algolia.instantsearch.android.paging3.sortby.internal.SortByConnectionPaginator
 import com.algolia.instantsearch.core.connection.Connection
@@ -14,7 +13,6 @@ import com.algolia.instantsearch.helper.sortby.SortByViewModel
  *
  * @param paginator paginator to be connected
  */
-@ExperimentalInstantSearch
 public fun <T : Any> SortByViewModel.connectPagedList(paginator: Paginator<T>): Connection {
     return SortByConnectionPaginator(this, paginator)
 }
@@ -24,7 +22,6 @@ public fun <T : Any> SortByViewModel.connectPagedList(paginator: Paginator<T>): 
  *
  * @param paginator paginator to be connected
  */
-@ExperimentalInstantSearch
 public fun <S, T> SortByConnector<S>.connectPagedList(
     paginator: Paginator<T>
 ): Connection where S : Searcher<*>, S : IndexNameHolder, T : Any {

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/sortby/internal/SortByConnectionPaginator.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/sortby/internal/SortByConnectionPaginator.kt
@@ -1,6 +1,5 @@
 package com.algolia.instantsearch.android.paging3.sortby.internal
 
-import com.algolia.instantsearch.ExperimentalInstantSearch
 import com.algolia.instantsearch.android.paging3.Paginator
 import com.algolia.instantsearch.core.Callback
 import com.algolia.instantsearch.core.connection.ConnectionImpl
@@ -12,7 +11,6 @@ import com.algolia.instantsearch.helper.sortby.SortByViewModel
  * @param viewModel SortBy ViewModel to connect
  * @param paginator PagingData handler to connect
  */
-@ExperimentalInstantSearch
 internal class SortByConnectionPaginator<T : Any>(
     private val viewModel: SortByViewModel,
     private val paginator: Paginator<T>,

--- a/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/sortby/internal/SortByConnectionPaginator.kt
+++ b/extensions/android-paging3/src/main/kotlin/com/algolia/instantsearch/android/paging3/sortby/internal/SortByConnectionPaginator.kt
@@ -1,7 +1,7 @@
-package com.algolia.instantsearch.compose.sortby.internal
+package com.algolia.instantsearch.android.paging3.sortby.internal
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
-import com.algolia.instantsearch.compose.list.Paginator
+import com.algolia.instantsearch.android.paging3.Paginator
 import com.algolia.instantsearch.core.Callback
 import com.algolia.instantsearch.core.connection.ConnectionImpl
 import com.algolia.instantsearch.helper.sortby.SortByViewModel

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ algolia-client = "1.12.0"
 algolia-telemetry = "0.1.0"
 compose = "1.0.5"
 paging-compose = "1.0.0-alpha14"
+paging = "3.0.0"
 coroutines = "1.5.2-native-mt"
 ktor = "1.6.7"
 work = "2.7.1"
@@ -25,6 +26,7 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref 
 androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "compose" }
 androidx-compose-paging = { group = "androidx.paging", name = "paging-compose", version.ref = "paging-compose" }
+androidx-paging-common = { group = "androidx.paging", name = "paging-common", version.ref = "paging" }
 androidx-work = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.7.0" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version = "1.4.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ algolia-client = "1.12.0"
 algolia-telemetry = "0.1.0"
 compose = "1.0.5"
 paging-compose = "1.0.0-alpha14"
-paging = "3.0.0"
 coroutines = "1.5.2-native-mt"
 ktor = "1.6.7"
 work = "2.7.1"
@@ -26,11 +25,11 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref 
 androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "compose" }
 androidx-compose-paging = { group = "androidx.paging", name = "paging-compose", version.ref = "paging-compose" }
-androidx-paging-common = { group = "androidx.paging", name = "paging-common", version.ref = "paging" }
+androidx-paging3-common = { group = "androidx.paging", name = "paging-common", version = "3.0.0" }
 androidx-work = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.7.0" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version = "1.4.0" }
-androidx-paging = { group = "androidx.paging", name = "paging-runtime", version = "2.1.2" }
+androidx-paging2 = { group = "androidx.paging", name = "paging-runtime", version = "2.1.2" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version = "1.2.1" }
 androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version = "1.1.0" }
 google-material = { group = "com.google.android.material", name = "material", version = "1.4.0" }

--- a/instantsearch/build.gradle.kts
+++ b/instantsearch/build.gradle.kts
@@ -91,7 +91,7 @@ kotlin {
                 api(libs.androidx.core)
                 api(libs.androidx.appcompat)
                 api(libs.androidx.swiperefreshlayout)
-                api(libs.androidx.paging)
+                api(libs.androidx.paging2)
                 api(libs.kotlinx.coroutines.android)
                 api(libs.google.material)
             }

--- a/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/filter/state/FilterStateConnection.kt
+++ b/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/filter/state/FilterStateConnection.kt
@@ -6,6 +6,7 @@ import com.algolia.instantsearch.core.connection.Connection
 import com.algolia.instantsearch.helper.android.filter.state.internal.FilterStateConnectionPagedList
 import com.algolia.instantsearch.helper.filter.state.FilterState
 
+@Deprecated("use Paginator from InstantSearch Android Paging3 extension package instead")
 public fun <T> FilterState.connectPagedList(pagedList: LiveData<PagedList<T>>): Connection {
     return FilterStateConnectionPagedList(pagedList, this)
 }

--- a/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/searchbox/SearchBoxConnection.kt
+++ b/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/searchbox/SearchBoxConnection.kt
@@ -12,6 +12,7 @@ import com.algolia.instantsearch.core.searcher.debounceSearchInMillis
 import com.algolia.instantsearch.helper.android.searchbox.internal.SearchBoxConnectionSearcherPagedList
 import com.algolia.instantsearch.helper.searchbox.SearchMode
 
+@Deprecated("use Paginator from InstantSearch Android Paging3 extension package instead")
 public fun <R> SearchBoxViewModel.connectSearcher(
     searcher: Searcher<R>,
     pagedList: List<LiveData<out PagedList<out Any>>>,

--- a/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/searchbox/SearchBoxConnectorPagedList.kt
+++ b/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/searchbox/SearchBoxConnectorPagedList.kt
@@ -9,6 +9,7 @@ import com.algolia.instantsearch.core.searcher.Searcher
 import com.algolia.instantsearch.core.searcher.debounceSearchInMillis
 import com.algolia.instantsearch.helper.searchbox.SearchMode
 
+@Deprecated("use Paginator from InstantSearch Android Paging3 extension package instead")
 public data class SearchBoxConnectorPagedList<R>(
     public val searcher: Searcher<R>,
     public val pagedList: List<LiveData<out PagedList<out Any>>>,
@@ -17,6 +18,7 @@ public data class SearchBoxConnectorPagedList<R>(
     public val debouncer: Debouncer = Debouncer(debounceSearchInMillis),
 ) : ConnectionImpl() {
 
+    @Suppress("DEPRECATION")
     private val connectionSearcher = viewModel.connectSearcher(searcher, pagedList, searchMode, debouncer)
 
     override fun connect() {

--- a/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnection.kt
+++ b/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/helper/android/sortby/SortByConnection.kt
@@ -9,10 +9,12 @@ import com.algolia.instantsearch.helper.searcher.IndexNameHolder
 import com.algolia.instantsearch.helper.sortby.SortByConnector
 import com.algolia.instantsearch.helper.sortby.SortByViewModel
 
+@Deprecated("use Paginator from InstantSearch Android Paging3 extension package instead")
 public fun <T> SortByViewModel.connectPagedList(pagedList: LiveData<PagedList<T>>): Connection {
     return SortByConnectionPagedList(this, pagedList)
 }
 
+@Deprecated("use Paginator from InstantSearch Android Paging3 extension package instead")
 public fun <S, T> SortByConnector<S>.connectPagedList(
     pagedList: LiveData<PagedList<T>>
 ): Connection where S : Searcher<*>, S : IndexNameHolder {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ include(":instantsearch-core")
 include(":instantsearch-insights")
 include(":instantsearch-compose")
 include(":instantsearch-utils")
+include(":extensions:android-paging3")
 
 val localSettings = file("local.settings.gradle.kts")
 if (localSettings.exists()) {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Introduce androidx paging 3 support as a new package `instantsearch-android-paging3`, and allows the separation of instant search android and paging libraries integration.
