### PR TITLE
feat: add `setBoundsFromFacetStats` to `FilterComparisonConnector`

### DIFF
--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/numeric/comparison/FilterComparisonComputeBounds.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/numeric/comparison/FilterComparisonComputeBounds.kt
@@ -2,6 +2,7 @@ package com.algolia.instantsearch.filter.numeric.comparison
 
 import com.algolia.instantsearch.core.number.NumberViewModel
 import com.algolia.instantsearch.core.number.range.Range
+import com.algolia.instantsearch.filter.range.internal.mapperOf
 import com.algolia.search.model.Attribute
 import com.algolia.search.model.search.FacetStats
 
@@ -41,4 +42,32 @@ public fun NumberViewModel<Double>.setBoundsFromFacetStatsDouble(
     facetStats: Map<Attribute, FacetStats>,
 ) {
     setBoundsFromFacetStats(attribute, facetStats) { it.toDouble() }
+}
+
+/**
+ * Set filter bounds from [FacetStats].
+ *
+ * @param attribute attribute to get its bounds
+ * @param facetStats facet stats to get bounds from
+ */
+public inline fun <reified T> FilterComparisonConnector<T>.setBoundsFromFacetStats(
+    attribute: Attribute,
+    facetStats: Map<Attribute, FacetStats>
+) where T : Number, T : Comparable<T> {
+    setBoundsFromFacetStats(attribute, facetStats, mapperOf(T::class))
+}
+
+/**
+ * Set filter bounds from [FacetStats].
+ *
+ * @param attribute attribute to get its bounds
+ * @param facetStats facet stats to get bounds from
+ * @param transform mapper from [Number] to [T]
+ */
+public fun <T> FilterComparisonConnector<T>.setBoundsFromFacetStats(
+    attribute: Attribute,
+    facetStats: Map<Attribute, FacetStats>,
+    transform: (Number) -> T,
+) where T : Number, T : Comparable<T> {
+    viewModel.setBoundsFromFacetStats(attribute, facetStats, transform)
 }

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/Mapper.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/Mapper.kt
@@ -8,6 +8,7 @@ import kotlin.reflect.KClass
  * @param clazz the numeric type class to get its mapper.
  */
 @Suppress("UNCHECKED_CAST")
+@PublishedApi
 internal fun <T> mapperOf(clazz: KClass<T>): (Number) -> T where T : Number, T : Comparable<T> {
     return when (clazz) {
         Int::class -> { number -> number.toInt() as T }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Add missing `setBoundsFromFacetStats` to `FilterComparisonConnector`
