### PR TITLE
chore: print searcher exception stacktrace

### DIFF
--- a/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/extension/Log.kt
+++ b/instantsearch/src/androidMain/kotlin/com/algolia/instantsearch/extension/Log.kt
@@ -1,0 +1,7 @@
+package com.algolia.instantsearch.extension
+
+import android.util.Log
+
+internal actual fun printError(message: String) {
+    Log.e("InstantSearch", message)
+}

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/extension/Utils.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/extension/Utils.kt
@@ -7,3 +7,5 @@ internal fun <T> tryOrNull(block: () -> T): T? {
         null
     }
 }
+
+internal expect fun printError(message: String)

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/internal/SearcherExceptionHandler.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/internal/SearcherExceptionHandler.kt
@@ -1,9 +1,10 @@
 package com.algolia.instantsearch.searcher.internal
 
 import com.algolia.instantsearch.core.searcher.Searcher
-import kotlinx.coroutines.CoroutineExceptionHandler
+import com.algolia.instantsearch.extension.printError
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineExceptionHandler
 
 /**
  * Searcher exception handler.
@@ -14,6 +15,7 @@ internal class SearcherExceptionHandler<R>(
 ) : AbstractCoroutineContextElement(CoroutineExceptionHandler), CoroutineExceptionHandler {
 
     override fun handleException(context: CoroutineContext, exception: Throwable) {
+        printError(exception.stackTraceToString())
         searcher.error.value = exception
         searcher.isLoading.value = false
     }

--- a/instantsearch/src/jvmMain/kotlin/com/algolia/instantsearch/extension/printError.kt
+++ b/instantsearch/src/jvmMain/kotlin/com/algolia/instantsearch/extension/printError.kt
@@ -1,0 +1,5 @@
+package com.algolia.instantsearch.extension
+
+internal actual fun printError(message: String) {
+    System.err.println(message)
+}


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

* Android: prints to `Log.e`
* JVM: standard error output
