### PR TITLE
fix: filter list numeric defaults

### DIFF
--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/androidview/filter/list/FilterListNumericShowcase.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/androidview/filter/list/FilterListNumericShowcase.kt
@@ -13,6 +13,7 @@ import com.algolia.instantsearch.examples.android.showcase.androidview.*
 import com.algolia.instantsearch.examples.android.databinding.HeaderFilterBinding
 import com.algolia.instantsearch.examples.android.databinding.IncludeListBinding
 import com.algolia.instantsearch.examples.android.databinding.ShowcaseFilterListBinding
+import com.algolia.instantsearch.filter.state.groupOr
 import com.algolia.search.model.Attribute
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.filter.NumericOperator
@@ -20,7 +21,7 @@ import com.algolia.search.model.filter.NumericOperator
 class FilterListNumericShowcase : AppCompatActivity() {
 
     private val price = Attribute("price")
-    private val groupPrice = groupAnd(price)
+    private val groupPrice = groupOr(price)
     private val searcher = HitsSearcher(client, stubIndexName)
     private val filterState = FilterState()
     private val filters = listOf(

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/androidview/filter/list/FilterListNumericShowcase.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/androidview/filter/list/FilterListNumericShowcase.kt
@@ -3,17 +3,25 @@ package com.algolia.instantsearch.examples.android.showcase.androidview.filter.l
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.algolia.instantsearch.core.connection.ConnectionHandler
-import com.algolia.instantsearch.filter.list.FilterListConnector
-import com.algolia.instantsearch.filter.list.connectView
-import com.algolia.instantsearch.filter.state.FilterState
-import com.algolia.instantsearch.filter.state.groupAnd
-import com.algolia.instantsearch.searcher.connectFilterState
-import com.algolia.instantsearch.searcher.hits.HitsSearcher
-import com.algolia.instantsearch.examples.android.showcase.androidview.*
+import com.algolia.instantsearch.core.selectable.list.SelectionMode
 import com.algolia.instantsearch.examples.android.databinding.HeaderFilterBinding
 import com.algolia.instantsearch.examples.android.databinding.IncludeListBinding
 import com.algolia.instantsearch.examples.android.databinding.ShowcaseFilterListBinding
+import com.algolia.instantsearch.examples.android.showcase.androidview.client
+import com.algolia.instantsearch.examples.android.showcase.androidview.configureRecyclerView
+import com.algolia.instantsearch.examples.android.showcase.androidview.configureSearcher
+import com.algolia.instantsearch.examples.android.showcase.androidview.configureToolbar
+import com.algolia.instantsearch.examples.android.showcase.androidview.onClearAllThenClearFilters
+import com.algolia.instantsearch.examples.android.showcase.androidview.onErrorThenUpdateFiltersText
+import com.algolia.instantsearch.examples.android.showcase.androidview.onFilterChangedThenUpdateFiltersText
+import com.algolia.instantsearch.examples.android.showcase.androidview.onResponseChangedThenUpdateNbHits
+import com.algolia.instantsearch.examples.android.showcase.androidview.stubIndexName
+import com.algolia.instantsearch.filter.list.FilterListConnector
+import com.algolia.instantsearch.filter.list.connectView
+import com.algolia.instantsearch.filter.state.FilterState
 import com.algolia.instantsearch.filter.state.groupOr
+import com.algolia.instantsearch.searcher.connectFilterState
+import com.algolia.instantsearch.searcher.hits.HitsSearcher
 import com.algolia.search.model.Attribute
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.filter.NumericOperator
@@ -31,7 +39,12 @@ class FilterListNumericShowcase : AppCompatActivity() {
         Filter.Numeric(price, 25..100),
         Filter.Numeric(price, NumericOperator.Greater, 100)
     )
-    private val filterList = FilterListConnector.Numeric(filters, filterState, groupID = groupPrice)
+    private val filterList = FilterListConnector.Numeric(
+        filters = filters,
+        filterState = filterState,
+        groupID = groupPrice,
+        selectionMode = SelectionMode.Multiple
+    )
     private val connection = ConnectionHandler(filterList, searcher.connectFilterState(filterState))
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/filter/list/FilterListNumericShowcase.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/filter/list/FilterListNumericShowcase.kt
@@ -5,17 +5,17 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import com.algolia.instantsearch.compose.filter.list.FilterListState
 import com.algolia.instantsearch.core.connection.ConnectionHandler
-import com.algolia.instantsearch.filter.list.FilterListConnector
-import com.algolia.instantsearch.filter.list.connectView
-import com.algolia.instantsearch.filter.state.FilterState
-import com.algolia.instantsearch.filter.state.groupAnd
-import com.algolia.instantsearch.searcher.connectFilterState
-import com.algolia.instantsearch.searcher.hits.HitsSearcher
 import com.algolia.instantsearch.examples.android.showcase.compose.client
 import com.algolia.instantsearch.examples.android.showcase.compose.configureSearcher
 import com.algolia.instantsearch.examples.android.showcase.compose.filterColors
 import com.algolia.instantsearch.examples.android.showcase.compose.stubIndexName
 import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.HeaderFilterConnector
+import com.algolia.instantsearch.filter.list.FilterListConnector
+import com.algolia.instantsearch.filter.list.connectView
+import com.algolia.instantsearch.filter.state.FilterState
+import com.algolia.instantsearch.filter.state.groupOr
+import com.algolia.instantsearch.searcher.connectFilterState
+import com.algolia.instantsearch.searcher.hits.HitsSearcher
 import com.algolia.search.model.Attribute
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.filter.NumericOperator
@@ -24,7 +24,7 @@ import com.algolia.search.model.filter.NumericOperator
 class FilterListNumericShowcase : AppCompatActivity() {
 
     private val price = Attribute("price")
-    private val groupPrice = groupAnd(price)
+    private val groupPrice = groupOr(price)
     private val searcher = HitsSearcher(client, stubIndexName)
     private val filterState = FilterState()
     private val filters = listOf(

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/filter/list/FilterListNumericShowcase.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/filter/list/FilterListNumericShowcase.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import com.algolia.instantsearch.compose.filter.list.FilterListState
 import com.algolia.instantsearch.core.connection.ConnectionHandler
+import com.algolia.instantsearch.core.selectable.list.SelectionMode
 import com.algolia.instantsearch.examples.android.showcase.compose.client
 import com.algolia.instantsearch.examples.android.showcase.compose.configureSearcher
 import com.algolia.instantsearch.examples.android.showcase.compose.filterColors
@@ -36,8 +37,12 @@ class FilterListNumericShowcase : AppCompatActivity() {
     )
 
     private val filterListState = FilterListState<Filter.Numeric>()
-    private val filterList = FilterListConnector.Numeric(filters, filterState, groupID = groupPrice)
-
+    private val filterList = FilterListConnector.Numeric(
+        filters = filters,
+        filterState = filterState,
+        groupID = groupPrice,
+        selectionMode = SelectionMode.Multiple
+    )
     private val filterHeader = HeaderFilterConnector(
         searcher = searcher,
         filterState = filterState,

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/extension/Telemetry.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/extension/Telemetry.kt
@@ -181,7 +181,7 @@ internal fun FilterListViewModel.Numeric.traceNumericFilterList() {
 /** Telemetry: trace facet filter list connector */
 internal fun FilterListConnector.Numeric.traceNumericFilterListConnector() {
     val params = buildSet {
-        if (groupID.operator != FilterOperator.And) add(ComponentParam.Operator)
+        if (groupID.operator != FilterOperator.Or) add(ComponentParam.Operator)
     }
     Telemetry.shared.traceConnector(ComponentType.NumericFilterList, params)
 }

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/list/FilterListConnector.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/list/FilterListConnector.kt
@@ -92,7 +92,7 @@ public abstract class FilterListConnector<T : Filter> : AbstractConnection() {
             filters: List<Filter.Numeric>,
             filterState: FilterState,
             selectionMode: SelectionMode = SelectionMode.Single,
-            groupID: FilterGroupID = FilterGroupID(FilterOperator.And),
+            groupID: FilterGroupID = FilterGroupID(FilterOperator.Or),
         ) : this(filterState, FilterListViewModel.Numeric(filters, selectionMode), groupID)
 
         init {

--- a/instantsearch/src/commonTest/kotlin/telemetry/TestTelemetry.kt
+++ b/instantsearch/src/commonTest/kotlin/telemetry/TestTelemetry.kt
@@ -189,7 +189,7 @@ class TestTelemetry { // instrumented because it uses android's Base64
             listOf(Filter.Numeric(attribute, 1..4)),
             filterState,
             SelectionMode.Multiple,
-            FilterGroupID(FilterOperator.Or)
+            FilterGroupID(FilterOperator.And)
         )
         val component = Telemetry.shared.validateConnectorAndGet(ComponentType.NumericFilterList)
         assertEquals(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

* Update `FilterListConnector`'s default `groupID` to use `FilterOperator.Or`
* Update widget showcase