### PR TITLE
feat: insights timestamps generation configuration

### DIFF
--- a/instantsearch-insights/src/androidMain/kotlin/com/algolia/instantsearch/insights/internal/InsightsController.kt
+++ b/instantsearch-insights/src/androidMain/kotlin/com/algolia/instantsearch/insights/internal/InsightsController.kt
@@ -23,7 +23,7 @@ internal fun registerInsightsController(
     val saver = InsightsEventCache(localRepository)
     val uploader = InsightsEventUploader(localRepository, distantRepository)
     val worker = InsightsWorkManager(workManager, settings)
-    return InsightsController(indexName, worker, saver, uploader).also {
+    return InsightsController(indexName, worker, saver, uploader, configuration.generateTimestamps).also {
         it.userToken = configuration.defaultUserToken
         sharedInsights = it
         InsightsMap[indexName] = it

--- a/instantsearch-insights/src/androidMain/kotlin/com/algolia/instantsearch/insights/internal/InsightsController.kt
+++ b/instantsearch-insights/src/androidMain/kotlin/com/algolia/instantsearch/insights/internal/InsightsController.kt
@@ -18,7 +18,7 @@ internal fun registerInsightsController(
     distantRepository: InsightsDistantRepository,
     workManager: WorkManager,
     settings: InsightsSettings,
-    configuration: Insights.Configuration = Insights.Configuration(5000, 5000),
+    configuration: Insights.Configuration = Insights.Configuration(),
 ): Insights {
     val saver = InsightsEventCache(localRepository)
     val uploader = InsightsEventUploader(localRepository, distantRepository)

--- a/instantsearch-insights/src/androidTest/kotlin/com/algolia/instantsearch/insights/InsightsTest.kt
+++ b/instantsearch-insights/src/androidTest/kotlin/com/algolia/instantsearch/insights/InsightsTest.kt
@@ -155,7 +155,7 @@ internal class InsightsTest {
         }
         val cache = InsightsEventCache(localRepository)
         val uploader = InsightsEventUploader(localRepository, distantRepository)
-        val insights = InsightsController(indexName, eventUploader, cache, uploader)
+        val insights = InsightsController(indexName, eventUploader, cache, uploader, true)
         insights.userToken = UserToken("foo") // TODO: git stash apply to use default UUID token
         insights.clickedObjectIDs(eventClick.eventName, objectIDs)
         insights.clickedObjectIDsAfterSearch(
@@ -187,7 +187,7 @@ internal class InsightsTest {
         }
         val cache = InsightsEventCache(localRepository)
         val uploader = InsightsEventUploader(localRepository, distantRepository)
-        val insights = InsightsController(indexName, eventUploader, cache, uploader)
+        val insights = InsightsController(indexName, eventUploader, cache, uploader, true)
         insights.minBatchSize = 1 // Given an Insights that uploads every event
 
         insights.enabled = false // When a firstEvent is sent with insight disabled
@@ -204,7 +204,7 @@ internal class InsightsTest {
         val eventUploader = MinBatchSizeWorker(events, distantRepository, localRepository)
         val cache = InsightsEventCache(localRepository)
         val uploader = InsightsEventUploader(localRepository, distantRepository)
-        val insights = InsightsController(indexName, eventUploader, cache, uploader)
+        val insights = InsightsController(indexName, eventUploader, cache, uploader, true)
 
         // Given a minBatchSize of one and one event
         insights.minBatchSize = 1
@@ -252,7 +252,7 @@ internal class InsightsTest {
         val eventUploader = IntegrationWorker(events, distantRepository, localRepository)
         val cache = InsightsEventCache(localRepository)
         val uploader = InsightsEventUploader(localRepository, distantRepository)
-        val insights = InsightsController(indexName, eventUploader, cache, uploader).apply {
+        val insights = InsightsController(indexName, eventUploader, cache, uploader, true).apply {
             minBatchSize = 1
         }
 

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/FilterTrackable.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/FilterTrackable.kt
@@ -1,6 +1,5 @@
 package com.algolia.instantsearch.insights
 
-import com.algolia.instantsearch.insights.internal.extension.currentTimeMillis
 import com.algolia.search.model.filter.Filter
 import com.algolia.search.model.insights.EventName
 
@@ -11,12 +10,12 @@ public interface FilterTrackable {
      *
      * @param eventName the event's name, **must not be empty**.
      * @param filters the clicked filter(s).
-     * @param timestamp the time at which the view happened. Defaults to current time.
+     * @param timestamp the time at which the view happened.
      */
     public fun viewedFilters(
         eventName: EventName,
         filters: List<Filter.Facet>,
-        timestamp: Long = currentTimeMillis,
+        timestamp: Long? = null,
     )
 
     /**
@@ -24,24 +23,24 @@ public interface FilterTrackable {
      *
      * @param eventName the event's name, **must not be empty**.
      * @param filters the clicked filter(s).
-     * @param timestamp the time at which the click happened. Defaults to current time.
+     * @param timestamp the time at which the click happened.
      */
     public fun clickedFilters(
         eventName: EventName,
         filters: List<Filter.Facet>,
-        timestamp: Long = currentTimeMillis,
+        timestamp: Long? = null,
     )
 
     /**
      * Tracks a Conversion event, unrelated to a specific search query.
      *
      * @param eventName the event's name, **must not be empty**.
-     * @param timestamp the time at which the conversion happened. Defaults to current time.
+     * @param timestamp the time at which the conversion happened.
      * @param filters the converted filter(s).
      */
     public fun convertedFilters(
         eventName: EventName,
         filters: List<Filter.Facet>,
-        timestamp: Long = currentTimeMillis,
+        timestamp: Long? = null,
     )
 }

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/HitsAfterSearchTrackable.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/HitsAfterSearchTrackable.kt
@@ -1,6 +1,5 @@
 package com.algolia.instantsearch.insights
 
-import com.algolia.instantsearch.insights.internal.extension.currentTimeMillis
 import com.algolia.search.model.ObjectID
 import com.algolia.search.model.QueryID
 import com.algolia.search.model.insights.EventName
@@ -17,7 +16,7 @@ public interface HitsAfterSearchTrackable {
     public fun viewedObjectIDs(
         eventName: EventName,
         objectIDs: List<ObjectID>,
-        timestamp: Long = currentTimeMillis,
+        timestamp: Long? = null,
     )
 
     /**
@@ -25,12 +24,12 @@ public interface HitsAfterSearchTrackable {
      *
      * @param eventName the event's name, **must not be empty**.
      * @param objectIDs the clicked object(s)' `objectID`.
-     * @param timestamp the time at which the click happened. Defaults to current time.
+     * @param timestamp the time at which the click happened.
      */
     public fun clickedObjectIDs(
         eventName: EventName,
         objectIDs: List<ObjectID>,
-        timestamp: Long = currentTimeMillis,
+        timestamp: Long? = null,
     )
 
     /**
@@ -38,12 +37,12 @@ public interface HitsAfterSearchTrackable {
      *
      * @param eventName the event's name, **must not be empty**.
      * @param objectIDs the object(s)' `objectID`.
-     * @param timestamp the time at which the conversion happened. Defaults to current time.
+     * @param timestamp the time at which the conversion happened.
      */
     public fun convertedObjectIDs(
         eventName: EventName,
         objectIDs: List<ObjectID>,
-        timestamp: Long = currentTimeMillis,
+        timestamp: Long? = null,
     )
 
     /**
@@ -53,14 +52,14 @@ public interface HitsAfterSearchTrackable {
      * @param queryID the related [query's identifier][https://www.algolia.com/doc/guides/insights-and-analytics/click-analytics/?language=php#identifying-the-query-result-position].
      * @param objectIDs the object(s)' `objectID`.
      * @param positions the clicked object(s)' position(s).
-     * @param timestamp the time at which the click happened. Defaults to current time.
+     * @param timestamp the time at which the click happened.
      */
     public fun clickedObjectIDsAfterSearch(
         eventName: EventName,
         queryID: QueryID,
         objectIDs: List<ObjectID>,
         positions: List<Int>,
-        timestamp: Long = currentTimeMillis,
+        timestamp: Long? = null,
     )
 
     /**
@@ -69,12 +68,12 @@ public interface HitsAfterSearchTrackable {
      * @param eventName the event's name, **must not be empty**.
      * @param queryID the related [query's identifier][https://www.algolia.com/doc/guides/insights-and-analytics/click-analytics/?language=php#identifying-the-query-result-position].
      * @param objectIDs the object(s)' `objectID`.
-     * @param timestamp the time at which the conversion happened. Defaults to current time.
+     * @param timestamp the time at which the conversion happened.
      */
     public fun convertedObjectIDsAfterSearch(
         eventName: EventName,
         queryID: QueryID,
         objectIDs: List<ObjectID>,
-        timestamp: Long = currentTimeMillis,
+        timestamp: Long? = null,
     )
 }

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/Insights.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/Insights.kt
@@ -72,12 +72,12 @@ public interface Insights : HitsAfterSearchTrackable, FilterTrackable, Credentia
         /**
          * Maximum amount of time in milliseconds before a connect timeout
          */
-        public val connectTimeoutInMilliseconds: Long,
+        public val connectTimeoutInMilliseconds: Long = 5000,
 
         /**
          * Maximum amount of time in milliseconds before a read timeout.
          */
-        public val readTimeoutInMilliseconds: Long,
+        public val readTimeoutInMilliseconds: Long = 5000,
 
         /**
          * Default User Token.

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/Insights.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/Insights.kt
@@ -83,6 +83,13 @@ public interface Insights : HitsAfterSearchTrackable, FilterTrackable, Credentia
          * Default User Token.
          */
         public val defaultUserToken: UserToken? = null,
+
+        /**
+         * Defines if the timestamps of the events should be automatically attributed if not provided while calling the
+         * event capturing function. If set to `false`, the events will be sent without timestamp value and will be
+         * automatically attributed on the server, which may affect the accuracy of the events.
+         */
+        public val generateTimestamps: Boolean = true,
     )
 
     public companion object

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/InsightsController.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/InsightsController.kt
@@ -3,6 +3,7 @@ package com.algolia.instantsearch.insights.internal
 import com.algolia.instantsearch.insights.Insights
 import com.algolia.instantsearch.insights.exception.InsightsException
 import com.algolia.instantsearch.insights.internal.cache.InsightsCache
+import com.algolia.instantsearch.insights.internal.extension.copy
 import com.algolia.instantsearch.insights.internal.extension.currentTimeMillis
 import com.algolia.instantsearch.insights.internal.logging.InsightsLogger
 import com.algolia.instantsearch.insights.internal.uploader.InsightsUploader
@@ -58,7 +59,7 @@ internal class InsightsController(
             indexName = indexName,
             eventName = eventName,
             userToken = userTokenOrThrow(),
-            timestamp = effectiveTimestamp(timestamp),
+            timestamp = timestamp,
             resources = InsightsEvent.Resources.ObjectIDs(objectIDs)
         )
     )
@@ -72,7 +73,7 @@ internal class InsightsController(
             indexName = indexName,
             eventName = eventName,
             userToken = userTokenOrThrow(),
-            timestamp = effectiveTimestamp(timestamp),
+            timestamp = timestamp,
             resources = InsightsEvent.Resources.Filters(filters)
         )
     )
@@ -86,7 +87,7 @@ internal class InsightsController(
             indexName = indexName,
             eventName = eventName,
             userToken = userTokenOrThrow(),
-            timestamp = effectiveTimestamp(timestamp),
+            timestamp = timestamp,
             resources = InsightsEvent.Resources.ObjectIDs(objectIDs)
         )
     )
@@ -100,7 +101,7 @@ internal class InsightsController(
             indexName = indexName,
             eventName = eventName,
             userToken = userTokenOrThrow(),
-            timestamp = effectiveTimestamp(timestamp),
+            timestamp = timestamp,
             resources = InsightsEvent.Resources.Filters(filters)
         )
     )
@@ -116,7 +117,7 @@ internal class InsightsController(
             indexName = indexName,
             eventName = eventName,
             userToken = userTokenOrThrow(),
-            timestamp = effectiveTimestamp(timestamp),
+            timestamp = timestamp,
             resources = InsightsEvent.Resources.ObjectIDs(objectIDs),
             queryID = queryID,
             positions = positions
@@ -132,7 +133,7 @@ internal class InsightsController(
             indexName = indexName,
             eventName = eventName,
             userToken = userTokenOrThrow(),
-            timestamp = effectiveTimestamp(timestamp),
+            timestamp = timestamp,
             resources = InsightsEvent.Resources.Filters(filters)
         )
     )
@@ -146,7 +147,7 @@ internal class InsightsController(
             indexName = indexName,
             eventName = eventName,
             userToken = userTokenOrThrow(),
-            timestamp = effectiveTimestamp(timestamp),
+            timestamp = timestamp,
             resources = InsightsEvent.Resources.ObjectIDs(objectIDs)
         )
     )
@@ -161,7 +162,7 @@ internal class InsightsController(
             indexName = indexName,
             eventName = eventName,
             userToken = userTokenOrThrow(),
-            timestamp = effectiveTimestamp(timestamp),
+            timestamp = timestamp,
             resources = InsightsEvent.Resources.ObjectIDs(objectIDs),
             queryID = queryID
         )
@@ -174,8 +175,9 @@ internal class InsightsController(
     override fun converted(event: InsightsEvent.Conversion): Unit = track(event)
 
     override fun track(event: InsightsEvent) {
+        val insightEvent = effectiveEvent(event)
         if (enabled) {
-            cache.save(event)
+            cache.save(insightEvent)
             if (cache.size() >= minBatchSize) {
                 worker.startOneTimeUpload()
             }
@@ -185,10 +187,10 @@ internal class InsightsController(
     // endregion
 
     /**
-     * Get effective timestamp.
-     * Defaults to [currentTimeMillis] if [timestamp] is `null` and timestamp generation is enabled.
+     * Get effective insight event.
+     * Timestamp defaults to [currentTimeMillis] if [event]'s timestamp is `null` and timestamp generation is enabled.
      */
-    private fun effectiveTimestamp(timestamp: Long?): Long? {
-        return timestamp ?: if (generateTimestamps) currentTimeMillis else null
+    private fun effectiveEvent(event: InsightsEvent): InsightsEvent {
+        return if (generateTimestamps && event.timestamp == null) event.copy(timestamp = currentTimeMillis) else event
     }
 }

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/Insights.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/Insights.kt
@@ -36,7 +36,7 @@ internal fun clientInsights(
 internal fun defaultConfiguration(settings: InsightsSettings): Insights.Configuration {
     val userToken = UserToken(settings.storedUserToken())
     InsightsLogger.log("Insights user token: $userToken")
-    return Insights.Configuration(5000, 5000, userToken)
+    return Insights.Configuration(defaultUserToken = userToken)
 }
 
 /**

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/InsightsEvent.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/InsightsEvent.kt
@@ -1,0 +1,12 @@
+package com.algolia.instantsearch.insights.internal.extension
+
+import com.algolia.search.model.insights.InsightsEvent
+
+internal fun InsightsEvent.copy(timestamp: Long?): InsightsEvent {
+    return when (this) {
+        is InsightsEvent.View -> copy(timestamp = timestamp)
+        is InsightsEvent.Click -> copy(timestamp = timestamp)
+        is InsightsEvent.Conversion -> copy(timestamp = timestamp)
+    }
+}
+

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/InsightsEvent.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/InsightsEvent.kt
@@ -9,4 +9,3 @@ internal fun InsightsEvent.copy(timestamp: Long?): InsightsEvent {
         is InsightsEvent.Conversion -> copy(timestamp = timestamp)
     }
 }
-


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Add `Insights.Configuration(generateTimestamps: Long)` parameter.

Defines if the timestamps of the events should be automatically attributed if not provided while calling the event capturing function. If set to `false`, the events will be sent without timestamp value and will be automatically attributed on the server, which may affect the accuracy of the events.