### PR TITLE
chore: deprecate compose `SearchBox`

### DIFF
--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/categorieshits/SearchScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/categorieshits/SearchScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
 import com.algolia.instantsearch.compose.highlighting.toAnnotatedString
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 import com.algolia.instantsearch.core.highlighting.DefaultPostTag
 import com.algolia.instantsearch.core.highlighting.DefaultPreTag

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/multipleindex/SearchScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/multipleindex/SearchScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.algolia.instantsearch.compose.highlighting.toAnnotatedString
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 
 @Composable

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/suggestions/categories/SearchScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/suggestions/categories/SearchScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.algolia.instantsearch.compose.highlighting.toAnnotatedString
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 import com.algolia.instantsearch.core.highlighting.DefaultPostTag
 import com.algolia.instantsearch.core.highlighting.DefaultPreTag

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/suggestions/hits/SearchScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/suggestions/hits/SearchScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
 import com.algolia.instantsearch.compose.highlighting.toAnnotatedString
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 
 @Composable

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/suggestions/query/SearchScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/suggestions/query/SearchScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.algolia.instantsearch.compose.highlighting.toAnnotatedString
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 
 @Composable

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/suggestions/recent/SearchScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/suggestions/recent/SearchScreen.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.algolia.instantsearch.compose.highlighting.toAnnotatedString
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 
 @Composable

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/voice/SearchScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/codex/voice/SearchScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
 import com.algolia.instantsearch.compose.highlighting.toAnnotatedString
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 
 @Composable

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/guides/compose/SearchScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/guides/compose/SearchScreen.kt
@@ -27,7 +27,7 @@ import com.algolia.instantsearch.android.paging3.flow
 import com.algolia.instantsearch.compose.filter.facet.FacetListState
 import com.algolia.instantsearch.compose.highlighting.toAnnotatedString
 import com.algolia.instantsearch.compose.item.StatsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 import com.algolia.instantsearch.core.selectable.list.SelectableItem
 import com.algolia.instantsearch.examples.android.guides.model.Product

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/directory/DirectoryScreen.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/directory/DirectoryScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
+import com.algolia.instantsearch.examples.android.showcase.compose.ui.component.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 import com.algolia.instantsearch.compose.searchbox.defaultSearchBoxColors
 import com.algolia.instantsearch.examples.android.R

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/ui/component/SearchBox.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/ui/component/SearchBox.kt
@@ -1,0 +1,112 @@
+package com.algolia.instantsearch.examples.android.showcase.compose.ui.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldColors
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.algolia.instantsearch.compose.R
+import com.algolia.instantsearch.compose.searchbox.SearchBoxState
+
+@Composable
+fun SearchBox(
+    modifier: Modifier = Modifier,
+    searchBoxState: SearchBoxState = SearchBoxState(),
+    onValueChange: ((String, Boolean) -> Unit)? = null,
+    enabled: Boolean = true,
+    textStyle: TextStyle = LocalTextStyle.current,
+    placeHolderText: String = stringResource(R.string.alg_is_compose_search_box_hint),
+    colors: TextFieldColors = defaultSearchBoxColors(),
+    leadingIcon: @Composable (() -> Unit)? = { DefaultLeadingIcon() },
+    trailingIcon: @Composable (() -> Unit)? = { DefaultTrailingIcon(searchBoxState) },
+    elevation: Dp = 1.dp,
+) {
+    Surface(modifier = modifier, elevation = elevation) {
+        TextField(
+            value = searchBoxState.query,
+            textStyle = textStyle.merge(TextStyle(textDecoration = TextDecoration.None)),
+            onValueChange = {
+                searchBoxState.setText(it)
+                onValueChange?.invoke(it, false)
+            },
+            leadingIcon = leadingIcon,
+            placeholder = {
+                Text(text = placeHolderText)
+            },
+            trailingIcon = trailingIcon,
+            singleLine = true,
+            enabled = enabled,
+            colors = colors,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(
+                onSearch = {
+                    searchBoxState.setText(searchBoxState.query, true)
+                    onValueChange?.invoke(searchBoxState.query, true)
+                }
+            )
+        )
+    }
+}
+
+@Composable
+fun defaultSearchBoxColors(
+    textColor: Color = LocalContentColor.current.copy(LocalContentAlpha.current),
+    backgroundColor: Color = MaterialTheme.colors.surface,
+    onBackgroundColor: Color = MaterialTheme.colors.onSurface,
+): TextFieldColors {
+    return TextFieldDefaults.textFieldColors(
+        textColor = textColor,
+        backgroundColor = backgroundColor,
+        focusedIndicatorColor = Color.Transparent,
+        unfocusedIndicatorColor = Color.Transparent,
+        disabledIndicatorColor = Color.Transparent,
+        leadingIconColor = onBackgroundColor,
+        placeholderColor = onBackgroundColor.copy(alpha = 0.2f),
+    )
+}
+
+@Composable
+fun DefaultLeadingIcon() {
+    Icon(
+        imageVector = Icons.Filled.Search,
+        contentDescription = null,
+    )
+}
+
+@Composable
+fun DefaultTrailingIcon(searchBoxState: SearchBoxState) {
+    if (searchBoxState.query.isNotEmpty()) {
+        Icon(
+            imageVector = Icons.Default.Clear,
+            contentDescription = null,
+            tint = MaterialTheme.colors.onBackground,
+            modifier = Modifier.clickable(
+                onClick = { searchBoxState.setText(null) },
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            )
+        )
+    }
+}

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/ui/component/TopBar.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/showcase/compose/ui/component/TopBar.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.algolia.instantsearch.compose.searchbox.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 import com.algolia.instantsearch.examples.android.showcase.compose.ui.ShowcaseTheme
 import kotlinx.coroutines.CoroutineScope
@@ -132,10 +131,12 @@ fun SearchTopBar(
         },
         actions = {
             icon?.let {
-                Icon(it, null,
+                Icon(
+                    it, null,
                     Modifier
                         .padding(4.dp)
-                        .clickable(onClick = onIconClick))
+                        .clickable(onClick = onIconClick)
+                )
             }
         }
     )

--- a/examples/androidtv/src/main/java/com/algolia/instantsearch/examples/androidtv/SearchScreen.kt
+++ b/examples/androidtv/src/main/java/com/algolia/instantsearch/examples/androidtv/SearchScreen.kt
@@ -27,12 +27,12 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
 import com.algolia.instantsearch.compose.hits.HitsState
-import com.algolia.instantsearch.compose.searchbox.SearchBox
 import com.algolia.instantsearch.compose.searchbox.SearchBoxState
 import com.algolia.instantsearch.compose.searchbox.defaultSearchBoxColors
-import com.algolia.instantsearch.examples.androidtv.ui.searchBackground
+import com.algolia.instantsearch.examples.androidtv.ui.SearchBox
 import com.algolia.instantsearch.examples.androidtv.ui.golden
 import com.algolia.instantsearch.examples.androidtv.ui.grey
+import com.algolia.instantsearch.examples.androidtv.ui.searchBackground
 import com.algolia.instantsearch.examples.androidtv.ui.white
 
 @Composable

--- a/examples/androidtv/src/main/java/com/algolia/instantsearch/examples/androidtv/ui/SearchBox.kt
+++ b/examples/androidtv/src/main/java/com/algolia/instantsearch/examples/androidtv/ui/SearchBox.kt
@@ -1,0 +1,112 @@
+package com.algolia.instantsearch.examples.androidtv.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldColors
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.algolia.instantsearch.compose.R
+import com.algolia.instantsearch.compose.searchbox.SearchBoxState
+
+@Composable
+fun SearchBox(
+    modifier: Modifier = Modifier,
+    searchBoxState: SearchBoxState = SearchBoxState(),
+    onValueChange: ((String, Boolean) -> Unit)? = null,
+    enabled: Boolean = true,
+    textStyle: TextStyle = LocalTextStyle.current,
+    placeHolderText: String = stringResource(R.string.alg_is_compose_search_box_hint),
+    colors: TextFieldColors = defaultSearchBoxColors(),
+    leadingIcon: @Composable (() -> Unit)? = { DefaultLeadingIcon() },
+    trailingIcon: @Composable (() -> Unit)? = { DefaultTrailingIcon(searchBoxState) },
+    elevation: Dp = 1.dp,
+) {
+    Surface(modifier = modifier, elevation = elevation) {
+        TextField(
+            value = searchBoxState.query,
+            textStyle = textStyle.merge(TextStyle(textDecoration = TextDecoration.None)),
+            onValueChange = {
+                searchBoxState.setText(it)
+                onValueChange?.invoke(it, false)
+            },
+            leadingIcon = leadingIcon,
+            placeholder = {
+                Text(text = placeHolderText)
+            },
+            trailingIcon = trailingIcon,
+            singleLine = true,
+            enabled = enabled,
+            colors = colors,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(
+                onSearch = {
+                    searchBoxState.setText(searchBoxState.query, true)
+                    onValueChange?.invoke(searchBoxState.query, true)
+                }
+            )
+        )
+    }
+}
+
+@Composable
+fun defaultSearchBoxColors(
+    textColor: Color = LocalContentColor.current.copy(LocalContentAlpha.current),
+    backgroundColor: Color = MaterialTheme.colors.surface,
+    onBackgroundColor: Color = MaterialTheme.colors.onSurface,
+): TextFieldColors {
+    return TextFieldDefaults.textFieldColors(
+        textColor = textColor,
+        backgroundColor = backgroundColor,
+        focusedIndicatorColor = Color.Transparent,
+        unfocusedIndicatorColor = Color.Transparent,
+        disabledIndicatorColor = Color.Transparent,
+        leadingIconColor = onBackgroundColor,
+        placeholderColor = onBackgroundColor.copy(alpha = 0.2f),
+    )
+}
+
+@Composable
+fun DefaultLeadingIcon() {
+    Icon(
+        imageVector = Icons.Filled.Search,
+        contentDescription = null,
+    )
+}
+
+@Composable
+fun DefaultTrailingIcon(searchBoxState: SearchBoxState) {
+    if (searchBoxState.query.isNotEmpty()) {
+        Icon(
+            imageVector = Icons.Default.Clear,
+            contentDescription = null,
+            tint = MaterialTheme.colors.onBackground,
+            modifier = Modifier.clickable(
+                onClick = { searchBoxState.setText(null) },
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            )
+        )
+    }
+}

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/searchbox/SearchBox.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/searchbox/SearchBox.kt
@@ -35,6 +35,7 @@ import com.algolia.instantsearch.compose.searchbox.internal.DefaultTrailingIcon
  * @param placeHolderText the placeholder to be displayed when the the input text is empty
  * @param elevation controls the size of the shadow below the surface
  */
+@Deprecated("implement your search box manually instead")
 @Composable
 public fun SearchBox(
     modifier: Modifier = Modifier,

--- a/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/searchbox/SearchBoxState.kt
+++ b/instantsearch-compose/src/main/java/com/algolia/instantsearch/compose/searchbox/SearchBoxState.kt
@@ -5,6 +5,29 @@ import com.algolia.instantsearch.core.searchbox.SearchBoxView
 
 /**
  * Search box query component for compose.
+ *
+ * Example using [SearchBoxState] with material's TextField:
+ *
+ * ```
+ * @Composable
+ * public fun SearchBox(
+ *     searchBoxState: SearchBoxState
+ * ) {
+ *     TextField(
+ *         // set query as text value
+ *         value = searchBoxState.query,
+ *         // update text on value change
+ *         onValueChange = { searchBoxState.setText(it) },
+ *
+ *         // set ime action to "search"
+ *         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+ *         // set text as query submit on search action
+ *         keyboardActions = KeyboardActions(
+ *             onSearch = { searchBoxState.setText(searchBoxState.query, true)}
+ *         )
+ *     )
+ * }
+ * ```
  */
 public interface SearchBoxState : SearchBoxView {
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | yes

## Description

Current implementation of `SearchBox` UI is hardly customizable, and depends on material.  
In this PR we deprecate the current implementation, with guidelines how to easily implement it.