### PR TITLE
refactor: deprecate `SearcherAnswers`

### DIFF
--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/SearcherAnswers.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/SearcherAnswers.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withContext
 /**
  * The component handling Algolia Answers search requests and managing the search sessions.
  */
+@Deprecated("Answers feature is deprecated")
 @ExperimentalInstantSearch
 @OptIn(ExperimentalAlgoliaClientAPI::class)
 public class SearcherAnswers(

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/SearcherConnection.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/SearcherConnection.kt
@@ -11,6 +11,7 @@ import com.algolia.instantsearch.searcher.internal.FacetsSearcherConnectionFilte
 import com.algolia.instantsearch.searcher.internal.HitsSearcherConnectionFilterState
 import com.algolia.instantsearch.searcher.internal.SearcherAnswersConnectionFilterState
 
+@Deprecated("Answers feature is deprecated")
 @ExperimentalInstantSearch
 public fun SearcherAnswers.connectFilterState(
     filterState: FilterState,

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/internal/SearcherAnswersConnectionFilterState.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/internal/SearcherAnswersConnectionFilterState.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.algolia.instantsearch.searcher.internal
 
 import com.algolia.instantsearch.ExperimentalInstantSearch
@@ -11,6 +13,7 @@ import com.algolia.instantsearch.searcher.SearcherAnswers
 import com.algolia.search.ExperimentalAlgoliaClientAPI
 import com.algolia.search.model.filter.FilterGroupsConverter
 
+@Deprecated("Answers feature is deprecated")
 @ExperimentalInstantSearch
 internal data class SearcherAnswersConnectionFilterState(
     private val searcher: SearcherAnswers,

--- a/instantsearch/src/commonTest/kotlin/searcher/Extensions.kt
+++ b/instantsearch/src/commonTest/kotlin/searcher/Extensions.kt
@@ -1,5 +1,8 @@
+@file:Suppress("DEPRECATION")
+
 package searcher
 
+import com.algolia.instantsearch.ExperimentalInstantSearch
 import com.algolia.instantsearch.searcher.SearcherAnswers
 import com.algolia.instantsearch.searcher.SearcherScope
 import com.algolia.instantsearch.searcher.facets.FacetsSearcher
@@ -26,7 +29,7 @@ fun TestSearcherForFacets(client: ClientSearch, indexName: IndexName, attribute:
     coroutineScope = TestCoroutineScope
 )
 
-@OptIn(com.algolia.instantsearch.ExperimentalInstantSearch::class)
+@OptIn(ExperimentalInstantSearch::class)
 fun TestSearcherAnswers(index: Index) = SearcherAnswers(
     index = index,
     coroutineScope = TestCoroutineScope

--- a/instantsearch/src/commonTest/kotlin/telemetry/TestTelemetry.kt
+++ b/instantsearch/src/commonTest/kotlin/telemetry/TestTelemetry.kt
@@ -50,11 +50,11 @@ import com.algolia.search.model.filter.NumericOperator
 import com.algolia.search.model.multipleindex.MultipleQueriesStrategy
 import com.algolia.search.model.search.Facet
 import com.algolia.search.transport.RequestOptions
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import mockClient
 import relatedItems.SimpleProduct
 import relatedItems.mockHitsView
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalInstantSearch::class, InternalInstantSearch::class)
 class TestTelemetry { // instrumented because it uses android's Base64
@@ -107,6 +107,7 @@ class TestTelemetry { // instrumented because it uses android's Base64
         assertEquals(false, component.isConnector)
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun testAnswersSearcher() {
         SearcherAnswers(client.initIndex(indexName), requestOptions = RequestOptions())


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Deprecate Answers widget: `SearcherAnswers`.