### PR TITLE
fix(filters): hierarchical items split seperator

### DIFF
--- a/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/tree/Extensions.kt
+++ b/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/tree/Extensions.kt
@@ -1,12 +1,10 @@
 package com.algolia.instantsearch.core.tree
 
-import com.algolia.instantsearch.core.tree.internal.DefaultSeparator
-
 public fun <T> Tree<T>.findNode(
+    separator: String,
     content: T,
-    separator: String = DefaultSeparator,
     isMatchingNode: (T, Node<T>, String) -> Boolean
-): Node<T>? = children.findNode(content, separator, isMatchingNode)
+): Node<T>? = children.findNode(separator, content, isMatchingNode)
 
 public fun <T> Tree<T>.findNode(
     content: T,
@@ -14,13 +12,13 @@ public fun <T> Tree<T>.findNode(
 ): Node<T>? = children.findNode(content, isMatchingNode)
 
 public fun <T> List<Node<T>>.findNode(
+    separator: String,
     content: T,
-    separator: String = DefaultSeparator,
     isMatchingNode: (T, Node<T>, String) -> Boolean
 ): Node<T>? {
     forEach { node ->
         if (isMatchingNode(content, node, separator))
-            return node.children.findNode(content, separator, isMatchingNode) ?: node
+            return node.children.findNode(separator, content, isMatchingNode) ?: node
     }
     return null
 }
@@ -36,8 +34,8 @@ public fun <T> List<Node<T>>.findNode(
 }
 
 public fun <T> List<T>.toNodes(
+    separator: String,
     isMatchingNode: (T, Node<T>, String) -> Boolean,
-    separator: String = DefaultSeparator,
     isSelected: ((T) -> Boolean)? = null
 ): Tree<T> {
     return map { Node(it, isSelected != null && isSelected.invoke(it)) }.asTree(separator, isMatchingNode)
@@ -51,11 +49,11 @@ public fun <T> List<T>.toNodes(
 }
 
 public fun <T> List<Node<T>>.asTree(
-    separator: String = DefaultSeparator,
+    separator: String,
     isMatchingNode: (T, Node<T>, String) -> Boolean
 ): Tree<T> = Tree<T>().also { tree ->
     forEach { node ->
-        val root = tree.findNode(node.content, separator, isMatchingNode)
+        val root = tree.findNode(separator, node.content, isMatchingNode)
 
         if (root != null) {
             root.children += node

--- a/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/tree/internal/Tree.kt
+++ b/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/tree/internal/Tree.kt
@@ -1,0 +1,3 @@
+package com.algolia.instantsearch.core.tree.internal
+
+internal const val DefaultSeparator = " . "

--- a/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/tree/internal/Tree.kt
+++ b/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/tree/internal/Tree.kt
@@ -1,3 +1,0 @@
-package com.algolia.instantsearch.core.tree.internal
-
-internal const val DefaultSeparator = " . "

--- a/instantsearch-core/src/commonTest/kotlin/tree/TestHierarchicalNode.kt
+++ b/instantsearch-core/src/commonTest/kotlin/tree/TestHierarchicalNode.kt
@@ -25,13 +25,14 @@ class TestHierarchicalNode {
     private val category312 = "Clothing > Men > Hats".toNode()
     private val category321 = "Clothing > Women > Shoes".toNode()
     private val category322 = "Clothing > Women > Bags".toNode()
+    private val separator = " > "
 
     private val isMatchingString: (String, Node<String>, String) -> Boolean = { str, node, _ ->
         str.startsWith(node.content)
     }
 
     private fun List<Node<String>>.findNode(content: String) =
-        findNode(content = content, isMatchingNode = isMatchingString)
+        findNode(content = content, separator = separator, isMatchingNode = isMatchingString)
 
     @Test
     fun findNodeShouldBeNull() {
@@ -65,7 +66,7 @@ class TestHierarchicalNode {
     @Test
     fun toNodes() {
         val values = listOf(category1.content, category2.content, category21.content, category22.content)
-        val nodes = values.toNodes(isMatchingString)
+        val nodes = values.toNodes(separator, isMatchingString)
         nodes shouldEqual Tree(
             mutableListOf(category1, category2.copy(children = mutableListOf(category21, category22)))
         )
@@ -74,7 +75,7 @@ class TestHierarchicalNode {
     @Test
     fun toNodesWithSelectedNode() {
         val values = listOf(category1, category2, category21, category22).map { it.content }
-        val nodes = values.toNodes(isMatchingString) {
+        val nodes = values.toNodes(separator, isMatchingString) {
             category21.content == it
         }
 
@@ -89,7 +90,8 @@ class TestHierarchicalNode {
             category311, category312, category321, category322
         )
 
-        nodes.asTree(" . ", isMatchingString) shouldEqual Tree(
+
+        nodes.asTree(separator, isMatchingString) shouldEqual Tree(
             mutableListOf(
                 category1,
                 category2.copy(children = mutableListOf(category21, category22)),

--- a/instantsearch-core/src/commonTest/kotlin/tree/TestHierarchicalNode.kt
+++ b/instantsearch-core/src/commonTest/kotlin/tree/TestHierarchicalNode.kt
@@ -5,10 +5,10 @@ import com.algolia.instantsearch.core.tree.Tree
 import com.algolia.instantsearch.core.tree.asTree
 import com.algolia.instantsearch.core.tree.findNode
 import com.algolia.instantsearch.core.tree.toNodes
+import kotlin.test.Test
 import shouldBeNull
 import shouldBeTrue
 import shouldEqual
-import kotlin.test.Test
 
 class TestHierarchicalNode {
 
@@ -26,11 +26,12 @@ class TestHierarchicalNode {
     private val category321 = "Clothing > Women > Shoes".toNode()
     private val category322 = "Clothing > Women > Bags".toNode()
 
-    private val isMatchingString: (String, Node<String>) -> Boolean = { str, node ->
+    private val isMatchingString: (String, Node<String>, String) -> Boolean = { str, node, _ ->
         str.startsWith(node.content)
     }
 
-    private fun List<Node<String>>.findNode(content: String) = findNode(content, isMatchingString)
+    private fun List<Node<String>>.findNode(content: String) =
+        findNode(content = content, isMatchingNode = isMatchingString)
 
     @Test
     fun findNodeShouldBeNull() {
@@ -88,7 +89,7 @@ class TestHierarchicalNode {
             category311, category312, category321, category322
         )
 
-        nodes.asTree(isMatchingString) shouldEqual Tree(
+        nodes.asTree(" . ", isMatchingString) shouldEqual Tree(
             mutableListOf(
                 category1,
                 category2.copy(children = mutableListOf(category21, category22)),

--- a/instantsearch-core/src/commonTest/kotlin/tree/TestTreeConnectView.kt
+++ b/instantsearch-core/src/commonTest/kotlin/tree/TestTreeConnectView.kt
@@ -23,7 +23,7 @@ class TestTreeConnectView {
     private val expectedSelection = shoesRunning
 
     private val presenter: TreePresenter<String, List<String>> = {
-        it.asTree(Comparator { a, b -> a.compareTo(b) }) { node, _, _ ->
+        it.asTree({ a, b -> a.compareTo(b) }) { node, _, _ ->
             node.content
         }
     }

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/internal/Extensions.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/internal/Extensions.kt
@@ -9,9 +9,11 @@ import com.algolia.instantsearch.hierarchical.HierarchicalTree
 import com.algolia.search.model.search.Facet
 import kotlin.math.min
 
-private val isMatchingFacetNode: (Facet, Node<Facet>) -> Boolean =
-    { content, node ->
-        val regexSeparator = Regex(" . ")
+internal const val DefaultSeparator = " . "
+
+private val isMatchingFacetNode: (Facet, Node<Facet>, String) -> Boolean =
+    { content, node, pattern ->
+        val regexSeparator = Regex(pattern)
         val splitContent: List<String> = content.value.split(regexSeparator)
         val splitNode: List<String> = node.content.value.split(regexSeparator)
         var isMatching = true
@@ -25,12 +27,18 @@ private val isMatchingFacetNode: (Facet, Node<Facet>) -> Boolean =
         isMatching
     }
 
-internal fun HierarchicalTree.findNode(facet: Facet) = findNode(facet, isMatchingFacetNode)
+internal fun HierarchicalTree.findNode(facet: Facet, separator: String = DefaultSeparator) =
+    findNode(facet, separator, isMatchingFacetNode)
 
-internal fun List<HierarchicalNode>.findNode(facet: Facet): HierarchicalNode? = findNode(facet, isMatchingFacetNode)
+internal fun List<HierarchicalNode>.findNode(facet: Facet, separator: String = DefaultSeparator): HierarchicalNode? =
+    findNode(facet, separator, isMatchingFacetNode)
 
-internal fun List<Facet>.toNodes(hierarchicalValue: String? = null): HierarchicalTree {
-    return toNodes(isMatchingFacetNode) { hierarchicalValue != null && it.value == hierarchicalValue }
+internal fun List<Facet>.toNodes(
+    hierarchicalValue: String? = null,
+    separator: String = DefaultSeparator
+): HierarchicalTree {
+    return toNodes(isMatchingFacetNode, separator) { hierarchicalValue != null && it.value == hierarchicalValue }
 }
 
-internal fun List<HierarchicalNode>.asTree(): HierarchicalTree = asTree(isMatchingFacetNode)
+internal fun List<HierarchicalNode>.asTree(separator: String = DefaultSeparator): HierarchicalTree =
+    asTree(separator, isMatchingFacetNode)

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/internal/Extensions.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/internal/Extensions.kt
@@ -28,16 +28,16 @@ private val isMatchingFacetNode: (Facet, Node<Facet>, String) -> Boolean =
     }
 
 internal fun HierarchicalTree.findNode(facet: Facet, separator: String = DefaultSeparator) =
-    findNode(facet, separator, isMatchingFacetNode)
+    findNode(separator, facet, isMatchingFacetNode)
 
 internal fun List<HierarchicalNode>.findNode(facet: Facet, separator: String = DefaultSeparator): HierarchicalNode? =
-    findNode(facet, separator, isMatchingFacetNode)
+    findNode(separator, facet, isMatchingFacetNode)
 
 internal fun List<Facet>.toNodes(
     hierarchicalValue: String? = null,
     separator: String = DefaultSeparator
 ): HierarchicalTree {
-    return toNodes(isMatchingFacetNode, separator) { hierarchicalValue != null && it.value == hierarchicalValue }
+    return toNodes(separator, isMatchingFacetNode) { hierarchicalValue != null && it.value == hierarchicalValue }
 }
 
 internal fun List<HierarchicalNode>.asTree(separator: String = DefaultSeparator): HierarchicalTree =

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/internal/HierarchicalConnectionSearcher.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/internal/HierarchicalConnectionSearcher.kt
@@ -22,7 +22,7 @@ internal data class HierarchicalConnectionSearcher(
                 .mapNotNull { facets[it]?.toMutableList() }
                 .filterUnprefixed()
                 .flatten()
-                .toNodes(selectedHierarchicalValue)
+                .toNodes(selectedHierarchicalValue, viewModel.separator)
         }
     }
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | FX-1551
| Need Doc update   | no


## Describe your change

While generating nodes items, facets with any separator will be split.
 
Example: `A > B - C` with `>` as separator with two levels: 
* with current behavior: 
   - lvl0: `A` 
   - lvl1: `B`
   - lvl2: `C`
* with the fix:
   - lvl0: `A`
   - lvl1: `B - C`
