### PR TITLE
fix(hierarchical): deselect item

### DIFF
--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/HierarchicalPath.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/HierarchicalPath.kt
@@ -2,4 +2,9 @@ package com.algolia.instantsearch.hierarchical
 
 import com.algolia.search.model.Attribute
 
+/**
+ * Hierarchical path in a tree.
+ *
+ * Example: [("lvl0", "A"), ("lvl1", "A > B"), ("lvl2", "A > B > C")]
+ */
 public typealias HierarchicalPath = List<Pair<Attribute, String>>

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/HierarchicalViewModel.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/HierarchicalViewModel.kt
@@ -36,15 +36,25 @@ public open class HierarchicalViewModel(
      */
     override fun computeSelections(key: String) {
         val selections = key.toSelectionList()
-        val hierarchicalPath = hierarchicalAttributes.mapIndexed { index, item ->
-            selections.getOrNull(index)?.let { item to it }
-        }.filterNotNull()
+        val updatedHierarchicalPath = hierarchicalAttributes
+            .mapIndexed { index, item -> selections.getOrNull(index)?.let { item to it } }
+            .filterNotNull()
+            .updateIfDeselect(hierarchicalPath.value)
 
-        this.hierarchicalPath.value = hierarchicalPath
-        eventHierarchicalPath.send(hierarchicalPath)
+        hierarchicalPath.value = updatedHierarchicalPath
+        eventHierarchicalPath.send(updatedHierarchicalPath)
     }
 
     private fun String.toSelectionList(): List<String> = split(separator).fold(listOf()) { acc, s ->
         acc + if (acc.isEmpty()) s else acc.last() + separator + s
+    }
+
+    /**
+     * Remove the last item from the hierarchical path if it's a deselection operation.
+     * Returning an empty list indicates that no item is selected.
+     */
+    private fun HierarchicalPath.updateIfDeselect(current: HierarchicalPath): HierarchicalPath {
+        if (this != current) return this // new path selected, nothing to do
+        return dropLast(1)
     }
 }

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/internal/HierarchicalConnectionFilterState.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/hierarchical/internal/HierarchicalConnectionFilterState.kt
@@ -23,6 +23,11 @@ internal data class HierarchicalConnectionFilterState(
 
     private val updateFilterState: Callback<HierarchicalPath> = { selections ->
         filterState.notify {
+            if (selections.isEmpty()) { // No item selected
+                remove(viewModel.attribute)
+                return@notify
+            }
+
             val last = selections.last()
             val filter = Filter.Facet(last.first, last.second)
             val path = selections.map { Filter.Facet(it.first, it.second) }

--- a/instantsearch/src/commonTest/kotlin/hierarchical/TestHierarchicalConnectFilterState.kt
+++ b/instantsearch/src/commonTest/kotlin/hierarchical/TestHierarchicalConnectFilterState.kt
@@ -9,9 +9,9 @@ import com.algolia.instantsearch.hierarchical.HierarchicalViewModel
 import com.algolia.instantsearch.hierarchical.connectFilterState
 import com.algolia.search.model.Attribute
 import com.algolia.search.model.search.Facet
+import kotlin.test.Test
 import shouldBeNull
 import shouldEqual
-import kotlin.test.Test
 
 class TestHierarchicalConnectFilterState {
 
@@ -87,5 +87,33 @@ class TestHierarchicalConnectFilterState {
             )
         }
         viewModel.selections.value shouldEqual listOf(facetBags.value)
+    }
+
+    @Test
+    fun onDeselectShouldUpdateFilterState() {
+        val viewModel = HierarchicalViewModel(category, categories, separator, tree)
+        val filterState = FilterState()
+        val connection = viewModel.connectFilterState(filterState)
+        connection.connect()
+
+        // Select from last level (lvl1)
+        viewModel.computeSelections(facetShoesRunning.value)
+        filterState.getHierarchicalFilters(category) shouldEqual HierarchicalFilter(
+            attributes = viewModel.hierarchicalAttributes,
+            filter = filterShoesRunning,
+            path = listOf(filterShoes, filterShoesRunning)
+        )
+
+        // Deselect the same item (lvl1) -> get up one level (lvl0)
+        viewModel.computeSelections(facetShoesRunning.value)
+        filterState.getHierarchicalFilters(category) shouldEqual HierarchicalFilter(
+            attributes = viewModel.hierarchicalAttributes,
+            filter = filterShoes,
+            path = listOf(filterShoes)
+        )
+
+        // Deselect the last item from (lvl0)
+        viewModel.computeSelections(facetShoes.value)
+        filterState.getHierarchicalFilters(category) shouldEqual null // corresponding filter should be removed
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | FX-1567
| Need Doc update   | no


## Describe your change

Calling `onSelectionChanged` on already selected item doesn't introduce any change to the hierarchical tree.
The expected behavior would be to deselect the item and update the hierarchical tree.

![hierarchical](https://user-images.githubusercontent.com/1970868/177557760-b0a9154c-f25f-4131-accb-c8617c1229ff.gif)

