### PR TITLE
fix(range): filter range bounds init

### DIFF
--- a/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/subscription/SubscriptionValue.kt
+++ b/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/subscription/SubscriptionValue.kt
@@ -1,5 +1,6 @@
 package com.algolia.instantsearch.core.subscription
 
+import com.algolia.instantsearch.core.subscription.internal.SubscriptionOnce
 import kotlin.properties.Delegates
 
 public class SubscriptionValue<T>(initialValue: T) : Subscription<T>() {
@@ -11,6 +12,10 @@ public class SubscriptionValue<T>(initialValue: T) : Subscription<T>() {
     public fun subscribePast(subscription: (T) -> Unit) {
         subscription(value)
         subscriptions += subscription
+    }
+
+    public fun subscribePastOnce(skipNull: Boolean = true, subscription: (T) -> Unit) {
+        subscriptions += SubscriptionOnce(this, skipNull, subscription)
     }
 
     public fun notifySubscriptions() {

--- a/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/subscription/internal/SubscriptionOnce.kt
+++ b/instantsearch-core/src/commonMain/kotlin/com/algolia/instantsearch/core/subscription/internal/SubscriptionOnce.kt
@@ -1,0 +1,20 @@
+package com.algolia.instantsearch.core.subscription.internal
+
+import com.algolia.instantsearch.core.subscription.Subscription
+
+internal class SubscriptionOnce<T>(
+    private val subscription: Subscription<T>,
+    private val skipNull: Boolean,
+    private val call: (T) -> Unit
+) : (T) -> Unit {
+
+    override fun invoke(value: T) {
+        if (value == null && skipNull) return
+        execute(value)
+    }
+
+    private fun execute(value: T) {
+        subscription.unsubscribe(this)
+        call(value)
+    }
+}

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/FilterRangeConnector.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/FilterRangeConnector.kt
@@ -47,17 +47,10 @@ public data class FilterRangeConnector<T>(
         range: ClosedRange<T>? = null,
     ) : this(
         FilterRangeViewModel(
-            range = range?.let { Range(it) } ?: bounds?.let { Range(it) },
-            bounds = bounds?.let { Range(it) } ?: range?.let { Range(it) }
+            range = range?.let { Range(it) },
+            bounds = bounds?.let { Range(it) }
         ),
         filterState, attribute
-    )
-
-    public constructor(
-        filterState: FilterState,
-        attribute: Attribute
-    ) : this(
-        FilterRangeViewModel(), filterState, attribute
     )
 
     private val connectionFilterState = viewModel.connectFilterState(filterState, attribute, groupID)

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/FilterRangeConnector.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/FilterRangeConnector.kt
@@ -26,6 +26,15 @@ public data class FilterRangeConnector<T>(
 ) : AbstractConnection() where T : Number, T : Comparable<T> {
 
     /**
+     * ```
+     * | Bounds/Range | connectSearcher | Behavior                                                                                                       |
+     * |--------------|-----------------|----------------------------------------------------------------------------------------------------------------|
+     * | Yes          | Yes             | The bounds retrieved from the first search operation, the range will match the value set using the constructor |
+     * | No           | Yes             | The bounds retrieved from the first search operation, the range will match the bounds                          |
+     * | Yes          | No              | The bounds/range from the constructor are used                                                                 |
+     * | No           | No              | Undefined behavior                                                                                             |
+     * ```
+     *
      * @param filterState the FilterState that will hold your filters
      * @param attribute the attribute to filter
      * @param bounds the limits of the acceptable range within which values will be coerced
@@ -38,10 +47,17 @@ public data class FilterRangeConnector<T>(
         range: ClosedRange<T>? = null,
     ) : this(
         FilterRangeViewModel(
-            range = range?.let { Range(it) },
-            bounds = bounds?.let { Range(it) }
+            range = range?.let { Range(it) } ?: bounds?.let { Range(it) },
+            bounds = bounds?.let { Range(it) } ?: range?.let { Range(it) }
         ),
         filterState, attribute
+    )
+
+    public constructor(
+        filterState: FilterState,
+        attribute: Attribute
+    ) : this(
+        FilterRangeViewModel(), filterState, attribute
     )
 
     private val connectionFilterState = viewModel.connectFilterState(filterState, attribute, groupID)

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/FilterRangeConnectionFilterState.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/FilterRangeConnectionFilterState.kt
@@ -26,7 +26,9 @@ internal data class FilterRangeConnectionFilterState<T>(
             .filterIsInstance<Filter.Numeric.Value.Range>()
             .firstOrNull()
 
-        viewModel.range.value = if (filter != null) Range(filter.lowerBound as T, filter.upperBound as T) else null
+        if (filter != null) { // avoid default range override to null
+            viewModel.range.value = Range(filter.lowerBound as T, filter.upperBound as T)
+        }
     }
     private val updateFilterState: Callback<Range<T>?> = { range ->
         filterState.notify {

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/FilterRangeConnectionSearcherImpl.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/FilterRangeConnectionSearcherImpl.kt
@@ -50,9 +50,7 @@ internal class FilterRangeConnectionSearcherImpl<T>(
     }
 
     private fun CommonSearchParameters.updateQueryFacets(attribute: Attribute) {
-        val current = facets?.toMutableSet() ?: mutableSetOf()
-        current.add(attribute)
-        facets = current
+        facets = (facets?.toMutableSet() ?: mutableSetOf()).apply { add(attribute) }
     }
 
     override fun disconnect() {

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/FilterRangeConnectionSearcherImpl.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/FilterRangeConnectionSearcherImpl.kt
@@ -43,12 +43,13 @@ internal class FilterRangeConnectionSearcherImpl<T>(
     override fun connect() {
         super.connect()
         searcher.query.updateQueryFacets(attribute)
-        searcher.response.subscribePast(responseSubscription)
+        searcher.response.subscribePastOnce(subscription = responseSubscription)
     }
 
     private fun CommonSearchParameters.updateQueryFacets(attribute: Attribute) {
         val current = facets?.toMutableSet() ?: mutableSetOf()
-        facets = if (!current.contains(attribute)) current + attribute else setOf(attribute)
+        current.add(attribute)
+        facets = current
     }
 
     override fun disconnect() {

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/FilterRangeConnectionSearcherImpl.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/range/internal/FilterRangeConnectionSearcherImpl.kt
@@ -38,6 +38,9 @@ internal class FilterRangeConnectionSearcherImpl<T>(
             val max = mapper(it.max)
             Range(min, max)
         }
+        if (range.value == null) { // if no range is specified, match the bounds.
+            range.value = bounds.value
+        }
     }
 
     override fun connect() {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | FX-1587
| Need Doc update   | no


## Describe your change

Fix bounds/range initialization to match the following:

| Bounds/Range | connectSearcher | Behavior                                                                                                       |
 |--------------|-----------------|----------------------------------------------------------------------------------------------------------------|
| Yes          | Yes             | The bounds retrieved from the first search operation, the range will match the value set using the constructor |
| No           | Yes             | The bounds retrieved from the first search operation, the range will match the bounds                          |
| Yes          | No              | The bounds/range from the constructor are used                                                                 |
| No           | No              | _Undefined behavior_                                                                                                                   |

