### PR TITLE
feat(DynamicFacetList): add default selection & faceting parameters

### DIFF
--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetConnection.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetConnection.kt
@@ -5,6 +5,7 @@ import com.algolia.instantsearch.filter.facet.dynamic.internal.DynamicFacetListC
 import com.algolia.instantsearch.filter.facet.dynamic.internal.DynamicFacetListConnectionSearcherIndex
 import com.algolia.instantsearch.filter.facet.dynamic.internal.DynamicFacetListConnectionView
 import com.algolia.instantsearch.filter.state.FilterGroupDescriptor
+import com.algolia.instantsearch.filter.state.FilterOperator
 import com.algolia.instantsearch.filter.state.FilterState
 import com.algolia.instantsearch.searcher.SearcherForHits
 import com.algolia.search.model.Attribute
@@ -26,9 +27,12 @@ public fun DynamicFacetListViewModel.connectSearcher(searcher: SearcherForHits<*
  * corresponding facet filters stored in the filter state. If no filter group descriptor provided, the filters for
  * attribute will be automatically stored in the conjunctive (`and`) group with the facet attribute name.
  */
-public fun DynamicFacetListViewModel.connectFilterState(filterState: FilterState, filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor> = emptyMap()): Connection {
-    return DynamicFacetListConnectionFilterState(this, filterState, filterGroupForAttribute)
-}
+public fun DynamicFacetListViewModel.connectFilterState(
+    filterState: FilterState,
+    filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor> = emptyMap(),
+    defaultFilterOperator: FilterOperator,
+): Connection =
+    DynamicFacetListConnectionFilterState(this, filterState, filterGroupForAttribute, defaultFilterOperator)
 
 /**
  * Establishes connection with a [DynamicFacetListView] implementation.

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetConnection.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetConnection.kt
@@ -25,7 +25,7 @@ public fun DynamicFacetListViewModel.connectSearcher(searcher: SearcherForHits<*
  * @param filterState filter state to connect
  * @param filterGroupForAttribute mapping between a facet attribute and a descriptor of a filter group where the
  * corresponding facet filters stored in the filter state. If no filter group descriptor provided, the filters for
- * attribute will be automatically stored in the conjunctive (`and`) group with the facet attribute name.
+ * attribute will be automatically stored in the group of `defaultFilterOperator` type with the facet attribute name.
  */
 public fun DynamicFacetListViewModel.connectFilterState(
     filterState: FilterState,

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetConnection.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetConnection.kt
@@ -30,7 +30,7 @@ public fun DynamicFacetListViewModel.connectSearcher(searcher: SearcherForHits<*
 public fun DynamicFacetListViewModel.connectFilterState(
     filterState: FilterState,
     filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor> = emptyMap(),
-    defaultFilterOperator: FilterOperator,
+    defaultFilterOperator: FilterOperator = FilterOperator.And,
 ): Connection =
     DynamicFacetListConnectionFilterState(this, filterState, filterGroupForAttribute, defaultFilterOperator)
 

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetListConnector.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetListConnector.kt
@@ -4,6 +4,7 @@ import com.algolia.instantsearch.core.connection.AbstractConnection
 import com.algolia.instantsearch.core.selectable.list.SelectionMode
 import com.algolia.instantsearch.extension.traceDynamicFacetConnector
 import com.algolia.instantsearch.filter.state.FilterGroupDescriptor
+import com.algolia.instantsearch.filter.state.FilterOperator
 import com.algolia.instantsearch.filter.state.FilterState
 import com.algolia.instantsearch.searcher.SearcherForHits
 import com.algolia.search.model.Attribute
@@ -23,7 +24,8 @@ public class DynamicFacetListConnector(
     public val searcher: SearcherForHits<*>,
     public val filterState: FilterState,
     public val viewModel: DynamicFacetListViewModel = DynamicFacetListViewModel(),
-    filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor> = emptyMap()
+    filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor> = emptyMap(),
+    defaultFilterOperator: FilterOperator = FilterOperator.And,
 ) : AbstractConnection() {
 
     /**
@@ -42,15 +44,24 @@ public class DynamicFacetListConnector(
         orderedFacets: List<AttributedFacets> = emptyList(),
         selections: SelectionsPerAttribute = mutableMapOf(),
         selectionModeForAttribute: Map<Attribute, SelectionMode> = emptyMap(),
-        filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor> = emptyMap()
-    ) : this(searcher, filterState, DynamicFacetListViewModel(orderedFacets, selections, selectionModeForAttribute), filterGroupForAttribute)
+        defaultSelectionMode: SelectionMode = SelectionMode.Single,
+        filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor> = emptyMap(),
+        defaultFilterOperator: FilterOperator = FilterOperator.And,
+    ) : this(
+        searcher,
+        filterState,
+        DynamicFacetListViewModel(orderedFacets, selections, selectionModeForAttribute, defaultSelectionMode),
+        filterGroupForAttribute,
+        defaultFilterOperator
+    )
 
     init {
         traceDynamicFacetConnector(filterGroupForAttribute)
     }
 
     private val searcherConnection = viewModel.connectSearcher(searcher)
-    private val filterStateConnection = viewModel.connectFilterState(filterState, filterGroupForAttribute)
+    private val filterStateConnection =
+        viewModel.connectFilterState(filterState, filterGroupForAttribute, defaultFilterOperator)
 
     override fun connect() {
         super.connect()

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetListViewModel.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/DynamicFacetListViewModel.kt
@@ -16,11 +16,16 @@ import kotlin.properties.Delegates
  * @param orderedFacets ordered list of attributed facets
  * @param selections mapping between a facet attribute and a set of selected facet values
  * @param selectionModeForAttribute Mapping between a facet attribute and a facet values selection mode
+ * @param defaultSelectionMode selection mode to apply for a facet list
  */
 public class DynamicFacetListViewModel(
     orderedFacets: List<AttributedFacets> = emptyList(),
     selections: SelectionsPerAttribute = mutableMapOf(),
-    selectionModeForAttribute: Map<Attribute, SelectionMode> = emptyMap()
+    selectionModeForAttribute: Map<Attribute, SelectionMode> = emptyMap(),
+    /**
+     * Selection mode to apply for a facet list..
+     */
+    public val defaultSelectionMode: SelectionMode = SelectionMode.Single,
 ) {
 
     init {
@@ -116,7 +121,7 @@ public class DynamicFacetListViewModel(
      * Create a facet selectable list for a given attribute.
      */
     private fun createFacetList(attribute: Attribute): SelectableListViewModel<String, Facet> {
-        val selectionMode = selectionModeForAttribute[attribute] ?: SelectionMode.Single
+        val selectionMode = selectionModeForAttribute[attribute] ?: defaultSelectionMode
         val facetList = SelectableListViewModel<String, Facet>(selectionMode = selectionMode)
         facetList.eventSelection.subscribe { selection ->
             val currentSelections = selections.toMutableMap()

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/internal/DynamicFacetListConnectionFilterState.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/internal/DynamicFacetListConnectionFilterState.kt
@@ -20,11 +20,13 @@ import com.algolia.search.model.filter.Filter
  * @param filterGroupForAttribute mapping between a facet attribute and a descriptor of a filter group where the
  * corresponding facet filters stored in the filter state. If no filter group descriptor provided, the filters for
  * attribute will be automatically stored in the conjunctive (`and`) group with the facet attribute name.
+ * @param defaultFilterOperator type of filter group created by default for a facet attribute
  */
 internal class DynamicFacetListConnectionFilterState(
     val viewModel: DynamicFacetListViewModel,
     val filterState: FilterState,
-    val filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor>
+    val filterGroupForAttribute: Map<Attribute, FilterGroupDescriptor>,
+    val defaultFilterOperator: FilterOperator,
 ) : AbstractConnection() {
 
     private val filterStateSubscription: Callback<Filters> = {
@@ -56,7 +58,7 @@ internal class DynamicFacetListConnectionFilterState(
     }
 
     private fun groupID(attribute: Attribute): FilterGroupID {
-        val (groupName, refinementOperator) = filterGroupForAttribute[attribute] ?: attribute to FilterOperator.And
+        val (groupName, refinementOperator) = filterGroupForAttribute[attribute] ?: (attribute to defaultFilterOperator)
         return when (refinementOperator) {
             FilterOperator.And -> FilterGroupID(groupName, FilterOperator.And)
             FilterOperator.Or -> FilterGroupID(groupName, FilterOperator.Or)

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/internal/DynamicFacetListConnectionFilterState.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/internal/DynamicFacetListConnectionFilterState.kt
@@ -19,7 +19,7 @@ import com.algolia.search.model.filter.Filter
  * @param filterState filterState that holds your filters
  * @param filterGroupForAttribute mapping between a facet attribute and a descriptor of a filter group where the
  * corresponding facet filters stored in the filter state. If no filter group descriptor provided, the filters for
- * attribute will be automatically stored in the conjunctive (`and`) group with the facet attribute name.
+ * attribute will be automatically stored in the group of `defaultFilterOperator` type with the facet attribute name.
  * @param defaultFilterOperator type of filter group created by default for a facet attribute
  */
 internal class DynamicFacetListConnectionFilterState(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

Add `defaultSelectionMode` and `defaultFilterOperator` parameters to DynamicFacetList components to customize their default behaviour. It will replace the hardcoded single selection, and filter group type.
