### PR TITLE
fix(DynamicFacetList):  ignoring of  disjunctive facets when updating orderedFacets

### DIFF
--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/internal/DynamicFacetListConnectionSearcherIndex.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/filter/facet/dynamic/internal/DynamicFacetListConnectionSearcherIndex.kt
@@ -23,8 +23,9 @@ internal class DynamicFacetListConnectionSearcherIndex(
 
     private val responseSubscription: Callback<ResponseSearch?> = { response ->
         val facetOrdering = response?.renderingContentOrNull?.facetOrdering
-        val facets = response?.facetsOrNull
-        viewModel.orderedFacets = buildOrder(facetOrdering, facets)
+        val facets = response?.facetsOrNull ?: emptyMap()
+        val disjunctiveFacets = response?.disjunctiveFacetsOrNull ?: emptyMap()
+        viewModel.orderedFacets = buildOrder(facetOrdering, facets.plus(disjunctiveFacets))
     }
 
     private fun buildOrder(ordering: FacetOrdering?, facets: Map<Attribute, List<Facet>>?): List<AttributedFacets> {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no
| Related Issue     | [CR-2980](https://algolia.atlassian.net/browse/CR-2980)
| Need Doc update   | no


## Describe your change

Duplicate of [the same issue in the InstantSearch iOS](https://github.com/algolia/instantsearch-ios/pull/258).

The disjunctive faceting doesn't work correctly with `DynamicFacetList` properly configured for disjunctive faceting.
This happens due to ignoring the `disjunctiveFacets` property of the `ResponseSearch` which contains the proper facet values when disjunctive faceting applied.

## What problem is this fixing?


The disjunctive faceting with `DynamicFacetList` works correctly.