### PR TITLE
feat(insights): add auto-sending hits view Insights events to HitsSearcher component

### DIFF
--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/hits/HitsSearcher.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/hits/HitsSearcher.kt
@@ -1,6 +1,5 @@
 package com.algolia.instantsearch.searcher.hits
 
-import com.algolia.instantsearch.insights.Insights
 import com.algolia.instantsearch.searcher.FilterGroupsHolder
 import com.algolia.instantsearch.searcher.IndexNameHolder
 import com.algolia.instantsearch.searcher.SearcherForHits
@@ -31,6 +30,14 @@ public interface HitsSearcher : SearcherForHits<Query>, IndexNameHolder, FilterG
      * Flag defining if disjunctive faceting is enabled.
      */
     public val isDisjunctiveFacetingEnabled: Boolean
+
+    /**
+     * Flag defining whether the automatic hits view Insights events sending is enabled.
+     *
+     * When this flag is set to true (default), the HitsSearcher automatically send Insights events
+     * with object IDs received from search results hits.
+     */
+    public var isAutoSendingHitsViewEvents: Boolean
 }
 
 /**
@@ -44,20 +51,20 @@ public interface HitsSearcher : SearcherForHits<Query>, IndexNameHolder, FilterG
  * @param coroutineScope scope of coroutine operations
  * @param coroutineDispatcher async search dispatcher
  * @param triggerSearchFor request condition
- * @param areEventsEnabled whether automatic view events sending for incoming hits is enabled
+ * @param isAutoSendingHitsViewEvents flag defining whether the automatic hits view Insights events sending is enabled
  * @param userToken the unique identifier for the user who triggered the view event
  */
 public fun HitsSearcher(
     client: ClientSearch,
-    insights: ClientInsights,
     indexName: IndexName,
     query: Query = Query(),
+    insights: ClientInsights = ClientInsights(client.applicationID, client.apiKey),
     requestOptions: RequestOptions? = null,
     isDisjunctiveFacetingEnabled: Boolean = true,
     coroutineScope: CoroutineScope = SearcherScope(),
     coroutineDispatcher: CoroutineDispatcher = defaultDispatcher,
     triggerSearchFor: SearchForQuery = SearchForQuery.All,
-    areEventsEnabled: Boolean = true,
+    isAutoSendingHitsViewEvents: Boolean = true,
     userToken: UserToken? = null,
 ): HitsSearcher = DefaultHitsSearcher(
     searchService = DefaultHitsSearchService(client),
@@ -69,7 +76,7 @@ public fun HitsSearcher(
     coroutineScope = coroutineScope,
     coroutineDispatcher = coroutineDispatcher,
     triggerSearchFor = triggerSearchFor,
-    areEventsEnabled = areEventsEnabled,
+    isAutoSendingHitsViewEvents = isAutoSendingHitsViewEvents,
     userToken = userToken
 )
 
@@ -82,7 +89,7 @@ public fun HitsSearcher(
  * @param query the query used for search
  * @param requestOptions request local configuration
  * @param coroutineScope scope of coroutine operations
- * @param areEventsEnabled whether automatic view events sending for incoming hits is enabled
+ * @param isAutoSendingHitsViewEvents flag defining whether the automatic hits view Insights events sending is enabled
  * @param userToken the unique identifier for the user who triggered the view event
  */
 public fun HitsSearcher(
@@ -95,7 +102,7 @@ public fun HitsSearcher(
     coroutineScope: CoroutineScope = SearcherScope(),
     coroutineDispatcher: CoroutineDispatcher = defaultDispatcher,
     triggerSearchFor: SearchForQuery = SearchForQuery.All,
-    areEventsEnabled: Boolean = true,
+    isAutoSendingHitsViewEvents: Boolean = true,
     userToken: UserToken? = null,
 ): HitsSearcher = HitsSearcher(
     client = ClientSearch(applicationID, apiKey),
@@ -107,7 +114,7 @@ public fun HitsSearcher(
     coroutineScope = coroutineScope,
     coroutineDispatcher = coroutineDispatcher,
     triggerSearchFor = triggerSearchFor,
-    areEventsEnabled = areEventsEnabled,
+    isAutoSendingHitsViewEvents = isAutoSendingHitsViewEvents,
     userToken = userToken,
 )
 
@@ -118,7 +125,7 @@ public fun HitsSearcher(
  * @param query the query used for search
  * @param requestOptions request local configuration
  * @param triggerSearchFor request condition
- * @param areEventsEnabled whether automatic view events sending for incoming hits is enabled
+ * @param isAutoSendingHitsViewEvents flag defining whether the automatic hits view Insights events sending is enabled
  * @param userToken the unique identifier for the user who triggered the view event
  */
 public fun MultiSearcher.addHitsSearcher(
@@ -127,8 +134,8 @@ public fun MultiSearcher.addHitsSearcher(
     requestOptions: RequestOptions? = null,
     isDisjunctiveFacetingEnabled: Boolean = true,
     triggerSearchFor: SearchForQuery = SearchForQuery.All,
-    areEventsEnabled: Boolean = true,
-    userToken: UserToken?,
+    isAutoSendingHitsViewEvents: Boolean = true,
+    userToken: UserToken? = null,
 ): HitsSearcher {
     return DefaultHitsSearcher(
         searchService = DefaultHitsSearchService(client),
@@ -140,7 +147,7 @@ public fun MultiSearcher.addHitsSearcher(
         coroutineScope = coroutineScope,
         coroutineDispatcher = coroutineDispatcher,
         triggerSearchFor = triggerSearchFor,
-        areEventsEnabled = areEventsEnabled,
+        isAutoSendingHitsViewEvents = isAutoSendingHitsViewEvents,
         userToken = userToken,
     ).also { addSearcher(it.asMultiSearchComponent()) }
 }

--- a/instantsearch/src/commonTest/kotlin/ClientInsights.kt
+++ b/instantsearch/src/commonTest/kotlin/ClientInsights.kt
@@ -3,19 +3,19 @@ import com.algolia.search.configuration.ConfigurationInsights
 import com.algolia.search.logging.LogLevel
 import com.algolia.search.model.APIKey
 import com.algolia.search.model.ApplicationID
-import io.ktor.client.engine.mock.*
-import io.ktor.client.request.*
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.request.HttpResponseData
 
-fun mockInsights(
+fun mockClientInsights(
     response: HttpResponseData? = null,
 ): ClientInsights {
     val mockEngine = if (response != null) MockEngine { response } else {
         defaultMockEngine
     }
-    return mockInsights(mockEngine)
+    return mockClientInsights(mockEngine)
 }
 
-fun mockInsights(
+fun mockClientInsights(
     mockEngine: MockEngine,
 ): ClientInsights {
     return ClientInsights(

--- a/instantsearch/src/commonTest/kotlin/Insights.kt.kt
+++ b/instantsearch/src/commonTest/kotlin/Insights.kt.kt
@@ -1,0 +1,29 @@
+import com.algolia.search.client.ClientInsights
+import com.algolia.search.configuration.ConfigurationInsights
+import com.algolia.search.logging.LogLevel
+import com.algolia.search.model.APIKey
+import com.algolia.search.model.ApplicationID
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.*
+
+fun mockInsights(
+    response: HttpResponseData? = null,
+): ClientInsights {
+    val mockEngine = if (response != null) MockEngine { response } else {
+        defaultMockEngine
+    }
+    return mockInsights(mockEngine)
+}
+
+fun mockInsights(
+    mockEngine: MockEngine,
+): ClientInsights {
+    return ClientInsights(
+        ConfigurationInsights(
+            ApplicationID("A"),
+            APIKey("B"),
+            engine = mockEngine,
+            logLevel = LogLevel.All
+        )
+    )
+}

--- a/instantsearch/src/commonTest/kotlin/searcher/Extensions.kt
+++ b/instantsearch/src/commonTest/kotlin/searcher/Extensions.kt
@@ -12,16 +12,22 @@ import com.algolia.search.client.ClientSearch
 import com.algolia.search.client.Index
 import com.algolia.search.model.Attribute
 import com.algolia.search.model.IndexName
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 
 val TestCoroutineScope = SearcherScope(Dispatchers.Default)
 
-fun TestSearcherSingle(client: ClientSearch, insights: ClientInsights, indexName: IndexName) = HitsSearcher(
+fun TestSearcherSingle(
+    client: ClientSearch,
+    indexName: IndexName,
+    insights: ClientInsights = ClientInsights(client.applicationID, client.apiKey),
+    coroutineScope: CoroutineScope = TestCoroutineScope,
+) = HitsSearcher(
     client = client,
     insights = insights,
     indexName = indexName,
     isDisjunctiveFacetingEnabled = false,
-    coroutineScope = TestCoroutineScope
+    coroutineScope = coroutineScope
 )
 
 fun TestSearcherForFacets(client: ClientSearch, indexName: IndexName, attribute: Attribute) = FacetsSearcher(

--- a/instantsearch/src/commonTest/kotlin/searcher/Extensions.kt
+++ b/instantsearch/src/commonTest/kotlin/searcher/Extensions.kt
@@ -7,6 +7,7 @@ import com.algolia.instantsearch.searcher.SearcherAnswers
 import com.algolia.instantsearch.searcher.SearcherScope
 import com.algolia.instantsearch.searcher.facets.FacetsSearcher
 import com.algolia.instantsearch.searcher.hits.HitsSearcher
+import com.algolia.search.client.ClientInsights
 import com.algolia.search.client.ClientSearch
 import com.algolia.search.client.Index
 import com.algolia.search.model.Attribute
@@ -15,8 +16,9 @@ import kotlinx.coroutines.Dispatchers
 
 val TestCoroutineScope = SearcherScope(Dispatchers.Default)
 
-fun TestSearcherSingle(client: ClientSearch, indexName: IndexName) = HitsSearcher(
+fun TestSearcherSingle(client: ClientSearch, insights: ClientInsights, indexName: IndexName) = HitsSearcher(
     client = client,
+    insights = insights,
     indexName = indexName,
     isDisjunctiveFacetingEnabled = false,
     coroutineScope = TestCoroutineScope

--- a/instantsearch/src/commonTest/kotlin/searcher/TestSearcherSingleIndex.kt
+++ b/instantsearch/src/commonTest/kotlin/searcher/TestSearcherSingleIndex.kt
@@ -4,6 +4,7 @@ import com.algolia.search.model.IndexName
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 import mockClient
+import mockInsights
 import respondBadRequest
 import responseSearch
 import shouldBeFalse
@@ -15,13 +16,14 @@ import shouldNotBeNull
 class TestSearcherSingleIndex {
 
     private val client = mockClient()
+    private val insights = mockInsights()
     private val indexName = IndexName("index")
     private val clientError = respondBadRequest()
     private val indexNameError = IndexName("index")
 
     @Test
     fun searchShouldUpdateLoading() = runTest {
-        val searcher = TestSearcherSingle(client, indexName)
+        val searcher = TestSearcherSingle(client, insights, indexName)
         var count = 0
 
         searcher.isLoading.subscribe { if (it) count++ }
@@ -32,7 +34,7 @@ class TestSearcherSingleIndex {
 
     @Test
     fun searchShouldUpdateResponse() = runTest {
-        val searcher = TestSearcherSingle(client, indexName)
+        val searcher = TestSearcherSingle(client, insights, indexName)
         var responded = false
 
         searcher.response.subscribe { responded = true }
@@ -45,7 +47,7 @@ class TestSearcherSingleIndex {
 
     @Test
     fun searchShouldUpdateError() = runTest {
-        val searcher = TestSearcherSingle(clientError, indexNameError)
+        val searcher = TestSearcherSingle(clientError, insights, indexNameError)
         var error = false
 
         searcher.error.subscribe { error = true }
@@ -54,5 +56,10 @@ class TestSearcherSingleIndex {
         searcher.error.value.shouldNotBeNull()
         searcher.response.value.shouldBeNull()
         error.shouldBeTrue()
+    }
+
+    @Test
+    fun searchShouldTriggerViewEvents() = runTest {
+        var searcher = TestSearcherSingle(client, insights, indexName)
     }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | [FX-2239](https://algolia.atlassian.net/browse/FX-2239)
| Need Doc update   | yes


## Describe your change

This pull request introduces a new feature to the `HitsSearcher` component, enabling automatic sending of hits view Insights events with object IDs received from search results hits. The addition simplifies tracking user interactions with search results and generating valuable analytics data.

The main changes include the introduction of a new flag `isAutoSendingHitsViewEvents` to the `HitsSearcher` component, which defaults to true, indicating that the automatic hits view Insights events sending is enabled by default. The logic to automatically send Insights events when search results are received and displayed has been implemented, based on the state of the `isAutoSendingHitsViewEvents` flag. Test cases have been added to ensure the correct behavior of the new feature when the flag is enabled or disabled.