### PR TITLE
fix(search): add a flag to disable auto search trigger

### DIFF
--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/guides/gettingstarted/MyViewModel.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/guides/gettingstarted/MyViewModel.kt
@@ -32,10 +32,10 @@ class MyViewModel : ViewModel() {
     )
     val paginator = Paginator(
         searcher = searcher,
-        pagingConfig = PagingConfig(pageSize = 50, enablePlaceholders = false),
+        pagingConfig = PagingConfig(pageSize = 20, enablePlaceholders = false),
         transformer = { hit -> hit.deserialize(Product.serializer()) }
     )
-    val searchBox = SearchBoxConnector(searcher)
+    val searchBox = SearchBoxConnector(searcher, searchOnQueryUpdate = false)
     val stats = StatsConnector(searcher)
 
     val filterState = FilterState()

--- a/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/guides/gettingstarted/ProductFragment.kt
+++ b/examples/android/src/main/kotlin/com/algolia/instantsearch/examples/android/guides/gettingstarted/ProductFragment.kt
@@ -10,6 +10,7 @@ import com.algolia.instantsearch.android.paging3.liveData
 import com.algolia.instantsearch.android.searchbox.SearchBoxViewAppCompat
 import com.algolia.instantsearch.android.stats.StatsTextView
 import com.algolia.instantsearch.core.connection.ConnectionHandler
+import com.algolia.instantsearch.core.searchbox.connectView
 import com.algolia.instantsearch.examples.android.R
 import com.algolia.instantsearch.examples.android.guides.extension.configure
 import com.algolia.instantsearch.searchbox.connectView

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searchbox/SearchBoxConnection.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searchbox/SearchBoxConnection.kt
@@ -13,8 +13,9 @@ public fun <R> SearchBoxViewModel.connectSearcher(
     searcher: Searcher<R>,
     searchMode: SearchMode = SearchMode.AsYouType,
     debouncer: Debouncer = Debouncer(debounceSearchInMillis),
+    searchOnQueryUpdate: Boolean = true,
 ): Connection {
-    return SearchBoxConnectionSearcher(this, searcher, searchMode, debouncer)
+    return SearchBoxConnectionSearcher(this, searcher, searchMode, debouncer, searchOnQueryUpdate)
 }
 
 /**

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searchbox/SearchBoxConnector.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searchbox/SearchBoxConnector.kt
@@ -21,9 +21,10 @@ public data class SearchBoxConnector<R>(
     public val viewModel: SearchBoxViewModel = SearchBoxViewModel(),
     public val searchMode: SearchMode = SearchMode.AsYouType,
     public val debouncer: Debouncer = Debouncer(debounceSearchInMillis),
+    public val searchOnQueryUpdate: Boolean = true,
 ) : AbstractConnection() {
 
-    private val connectionSearcher = viewModel.connectSearcher(searcher, searchMode, debouncer)
+    private val connectionSearcher = viewModel.connectSearcher(searcher, searchMode, debouncer, searchOnQueryUpdate)
 
     init {
         traceSearchBoxConnector()

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searchbox/internal/SearchBoxConnectionSearcher.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searchbox/internal/SearchBoxConnectionSearcher.kt
@@ -12,15 +12,20 @@ internal data class SearchBoxConnectionSearcher<R>(
     private val searcher: Searcher<R>,
     private val searchMode: SearchMode,
     private val debouncer: Debouncer,
+    private val searchOnQueryUpdate: Boolean,
 ) : AbstractConnection() {
 
     private val searchAsYouType: Callback<String?> = { query ->
         searcher.setQuery(query)
-        debouncer.debounce(searcher) { searchAsync() }
+        if (searchOnQueryUpdate) {
+            debouncer.debounce(searcher) { searchAsync() }
+        }
     }
     private val searchOnSubmit: Callback<String?> = { query ->
         searcher.setQuery(query)
-        searcher.searchAsync()
+        if (searchOnQueryUpdate) {
+            searcher.searchAsync()
+        }
     }
 
     override fun connect() {


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | n/a
| Need Doc update   | yes/no

## Describe your change

Adds a flag `searchOnQueryUpdate` to disable auto search trigger on query update.