### PR TITLE
fix(insights): add serializer parameters (#401)

### DIFF
--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/mapper/InsightsEventDOMapper.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/mapper/InsightsEventDOMapper.kt
@@ -2,16 +2,14 @@ package com.algolia.instantsearch.insights.internal.data.local.mapper
 
 import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO
 import com.algolia.instantsearch.insights.internal.extension.JsonNonStrict
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 
 internal object InsightsEventDOMapper : Mapper<InsightsEventDO, String> {
 
     override fun map(input: InsightsEventDO): String {
-        return JsonNonStrict.encodeToString(input)
+        return JsonNonStrict.encodeToString(InsightsEventDO.serializer(), input)
     }
 
     override fun unmap(input: String): InsightsEventDO {
-        return JsonNonStrict.decodeFromString(input)
+        return JsonNonStrict.decodeFromString(InsightsEventDO.serializer(), input)
     }
 }


### PR DESCRIPTION
Fixes crash when obfuscating.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | Fix #401  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->
Adds serializer parameters to `InsightsEventDOMapper` serialization calls.

## What problem is this fixing?

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->
Fixes a crash when obfuscating with R8 due to Kotlinx Serialization.
