### PR TITLE
fix(insights): disable events auto sending by default

### DIFF
--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/hits/HitsSearcher.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/searcher/hits/HitsSearcher.kt
@@ -77,7 +77,7 @@ public fun HitsSearcher(
     coroutineScope: CoroutineScope = SearcherScope(),
     coroutineDispatcher: CoroutineDispatcher = defaultDispatcher,
     triggerSearchFor: SearchForQuery = SearchForQuery.All,
-    isAutoSendingHitsViewEvents: Boolean = true,
+    isAutoSendingHitsViewEvents: Boolean = false,
     userToken: UserToken = UserToken.anonymous(),
 ): HitsSearcher = DefaultHitsSearcher(
     searchService = DefaultHitsSearchService(client),
@@ -117,7 +117,7 @@ public fun HitsSearcher(
     coroutineScope: CoroutineScope = SearcherScope(),
     coroutineDispatcher: CoroutineDispatcher = defaultDispatcher,
     triggerSearchFor: SearchForQuery = SearchForQuery.All,
-    isAutoSendingHitsViewEvents: Boolean = true,
+    isAutoSendingHitsViewEvents: Boolean = false,
     userToken: UserToken = UserToken.anonymous(),
 ): HitsSearcher = HitsSearcher(
     client = ClientSearch(applicationID, apiKey),
@@ -149,7 +149,7 @@ public fun MultiSearcher.addHitsSearcher(
     requestOptions: RequestOptions? = null,
     isDisjunctiveFacetingEnabled: Boolean = true,
     triggerSearchFor: SearchForQuery = SearchForQuery.All,
-    isAutoSendingHitsViewEvents: Boolean = true,
+    isAutoSendingHitsViewEvents: Boolean = false,
     userToken: UserToken = UserToken.anonymous(),
 ): HitsSearcher {
     return DefaultHitsSearcher(


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no
| Related Issue     | FX-2874
| Need Doc update   | no


## Describe your change

Set `isAutoSendingHitsViewEvents` to `false`