### PR TITLE
(feat): Add event subtype support to Insights

### DIFF
--- a/instantsearch-insights/src/androidUnitTest/kotlin/com/algolia/instantsearch/insights/InsightsTest.kt
+++ b/instantsearch-insights/src/androidUnitTest/kotlin/com/algolia/instantsearch/insights/InsightsTest.kt
@@ -9,13 +9,16 @@ import com.algolia.instantsearch.insights.internal.data.distant.InsightsDistantR
 import com.algolia.instantsearch.insights.internal.data.distant.InsightsHttpRepository
 import com.algolia.instantsearch.insights.internal.data.local.InsightsLocalRepository
 import com.algolia.instantsearch.insights.internal.data.local.mapper.FilterFacetMapper
+import com.algolia.instantsearch.insights.internal.data.local.mapper.InsightsEventsMapper
 import com.algolia.instantsearch.insights.internal.data.local.model.FilterFacetDO
 import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO
+import com.algolia.instantsearch.insights.internal.data.local.model.ObjectDataDO
 import com.algolia.instantsearch.insights.internal.extension.randomUUID
 import com.algolia.instantsearch.insights.internal.uploader.InsightsEventUploader
 import com.algolia.instantsearch.insights.internal.worker.InsightsManager
 import com.algolia.client.api.InsightsClient
 import com.algolia.client.configuration.ClientOptions
+import com.algolia.client.model.insights.*
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpStatusCode
@@ -579,4 +582,181 @@ internal class InsightsTest {
         assertEquals(1, stored.size)
         assertEquals("test-index", stored[0].indexName)
     }
+
+    // region Purchase event tests
+
+    private val eventPurchase = InsightsEventDO(
+        eventType = InsightsEventDO.EventType.Conversion,
+        eventSubtype = InsightsEventDO.EventSubtype.Purchase,
+        eventName = eventA,
+        indexName = indexName,
+        userToken = userToken,
+        timestamp = timestamp,
+        queryID = queryID,
+        objectIDs = objectIDs,
+        objectData = listOf(ObjectDataDO(queryID = queryID, price = 19.99, quantity = 2)),
+        currency = "USD",
+        value = 39.98,
+    )
+
+    private val eventAddToCart = InsightsEventDO(
+        eventType = InsightsEventDO.EventType.Conversion,
+        eventSubtype = InsightsEventDO.EventSubtype.AddToCart,
+        eventName = eventB,
+        indexName = indexName,
+        userToken = userToken,
+        timestamp = timestamp,
+        queryID = queryID,
+        objectIDs = objectIDs,
+        objectData = listOf(ObjectDataDO(queryID = queryID, price = 9.99, quantity = 1)),
+        currency = "EUR",
+        value = 9.99,
+    )
+
+    @Test
+    fun testPurchaseEvent() = runTest {
+        val response = webService.send(eventPurchase)
+        assertEquals(200, response.code)
+    }
+
+    @Test
+    fun testAddToCartEvent() = runTest {
+        val response = webService.send(eventAddToCart)
+        assertEquals(200, response.code)
+    }
+
+    @Test
+    fun testPurchasedObjectIDsSetsIndexName() {
+        val (controller, repo) = createControllerWithRepository()
+        controller.purchasedObjectIDs(
+            eventName = eventA,
+            objectIDs = objectIDs,
+        )
+        val stored = repo.read()
+        assertEquals(1, stored.size)
+        assertEquals("test-index", stored[0].indexName)
+        assertEquals(InsightsEventDO.EventSubtype.Purchase, stored[0].eventSubtype)
+    }
+
+    @Test
+    fun testPurchasedObjectIDsAfterSearchSetsIndexName() {
+        val (controller, repo) = createControllerWithRepository()
+        controller.purchasedObjectIDsAfterSearch(
+            eventName = eventA,
+            queryID = queryID,
+            objectIDs = objectIDs,
+        )
+        val stored = repo.read()
+        assertEquals(1, stored.size)
+        assertEquals("test-index", stored[0].indexName)
+        assertEquals(InsightsEventDO.EventSubtype.Purchase, stored[0].eventSubtype)
+        assertEquals(queryID, stored[0].queryID)
+    }
+
+    @Test
+    fun testAddedToCartObjectIDsSetsIndexName() {
+        val (controller, repo) = createControllerWithRepository()
+        controller.addedToCartObjectIDs(
+            eventName = eventA,
+            objectIDs = objectIDs,
+        )
+        val stored = repo.read()
+        assertEquals(1, stored.size)
+        assertEquals("test-index", stored[0].indexName)
+        assertEquals(InsightsEventDO.EventSubtype.AddToCart, stored[0].eventSubtype)
+    }
+
+    @Test
+    fun testAddedToCartObjectIDsAfterSearchSetsIndexName() {
+        val (controller, repo) = createControllerWithRepository()
+        controller.addedToCartObjectIDsAfterSearch(
+            eventName = eventA,
+            queryID = queryID,
+            objectIDs = objectIDs,
+        )
+        val stored = repo.read()
+        assertEquals(1, stored.size)
+        assertEquals("test-index", stored[0].indexName)
+        assertEquals(InsightsEventDO.EventSubtype.AddToCart, stored[0].eventSubtype)
+        assertEquals(queryID, stored[0].queryID)
+    }
+
+    @Test
+    fun testPurchaseWithObjectData() {
+        val (controller, repo) = createControllerWithRepository()
+        controller.purchasedObjectIDsAfterSearch(
+            eventName = eventA,
+            queryID = queryID,
+            objectIDs = objectIDs,
+            objectData = listOf(
+                ObjectDataAfterSearch(
+                    queryID = queryID,
+                    price = Price.of(19.99),
+                    quantity = 2,
+                    discount = Discount.of(5.0),
+                )
+            ),
+            currency = "USD",
+            value = Value.of(34.98),
+        )
+        val stored = repo.read()
+        assertEquals(1, stored.size)
+        val event = stored[0]
+        assertEquals(InsightsEventDO.EventSubtype.Purchase, event.eventSubtype)
+        assertEquals("USD", event.currency)
+        assertEquals(34.98, event.value)
+        assertNotNull(event.objectData)
+        assertEquals(1, event.objectData!!.size)
+        assertEquals(19.99, event.objectData!![0].price)
+        assertEquals(2, event.objectData!![0].quantity)
+        assertEquals(5.0, event.objectData!![0].discount)
+    }
+
+    @Test
+    fun testPurchaseEventRoundTripThroughMapper() {
+        val eventsItem = InsightsEventsMapper.doToEventsItem(eventPurchase)
+        assertNotNull(eventsItem)
+        assertTrue(eventsItem is EventsItems.PurchasedObjectIDsAfterSearchValue)
+        val roundTripped = InsightsEventsMapper.eventsItemToDO(eventsItem)
+        assertEquals(eventPurchase.eventType, roundTripped.eventType)
+        assertEquals(eventPurchase.eventSubtype, roundTripped.eventSubtype)
+        assertEquals(eventPurchase.eventName, roundTripped.eventName)
+        assertEquals(eventPurchase.indexName, roundTripped.indexName)
+        assertEquals(eventPurchase.objectIDs, roundTripped.objectIDs)
+        assertEquals(eventPurchase.queryID, roundTripped.queryID)
+        assertEquals(eventPurchase.currency, roundTripped.currency)
+    }
+
+    @Test
+    fun testAddToCartEventRoundTripThroughMapper() {
+        val eventsItem = InsightsEventsMapper.doToEventsItem(eventAddToCart)
+        assertNotNull(eventsItem)
+        assertTrue(eventsItem is EventsItems.AddedToCartObjectIDsAfterSearchValue)
+        val roundTripped = InsightsEventsMapper.eventsItemToDO(eventsItem)
+        assertEquals(eventAddToCart.eventType, roundTripped.eventType)
+        assertEquals(eventAddToCart.eventSubtype, roundTripped.eventSubtype)
+        assertEquals(eventAddToCart.eventName, roundTripped.eventName)
+        assertEquals(eventAddToCart.indexName, roundTripped.indexName)
+        assertEquals(eventAddToCart.objectIDs, roundTripped.objectIDs)
+        assertEquals(eventAddToCart.queryID, roundTripped.queryID)
+        assertEquals(eventAddToCart.currency, roundTripped.currency)
+    }
+
+    @Test
+    fun testPurchaseWithoutQueryIDMapsToPurchasedObjectIDs() {
+        val purchaseNoSearch = eventPurchase.copy(queryID = null, objectData = null)
+        val eventsItem = InsightsEventsMapper.doToEventsItem(purchaseNoSearch)
+        assertNotNull(eventsItem)
+        assertTrue(eventsItem is EventsItems.PurchasedObjectIDsValue)
+    }
+
+    @Test
+    fun testAddToCartWithoutQueryIDMapsToAddedToCartObjectIDs() {
+        val addToCartNoSearch = eventAddToCart.copy(queryID = null, objectData = null)
+        val eventsItem = InsightsEventsMapper.doToEventsItem(addToCartNoSearch)
+        assertNotNull(eventsItem)
+        assertTrue(eventsItem is EventsItems.AddedToCartObjectIDsValue)
+    }
+
+    // endregion
 }

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/HitsAfterSearchTrackable.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/HitsAfterSearchTrackable.kt
@@ -1,5 +1,9 @@
 package com.algolia.instantsearch.insights
 
+import com.algolia.client.model.insights.ObjectData
+import com.algolia.client.model.insights.ObjectDataAfterSearch
+import com.algolia.client.model.insights.Value
+
 public interface HitsAfterSearchTrackable {
 
     /**
@@ -70,6 +74,86 @@ public interface HitsAfterSearchTrackable {
         eventName: String,
         queryID: String,
         objectIDs: List<String>,
+        timestamp: Long? = null,
+    )
+
+    /**
+     * Tracks a Purchase event, unrelated to a specific search query.
+     *
+     * @param eventName the event's name, **must not be empty**.
+     * @param objectIDs the purchased object(s)' `objectID`.
+     * @param objectData extra information about the purchased items (price, quantity, discount).
+     * @param currency three-letter [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) currency code.
+     * @param value total monetary value of this event in units of [currency].
+     * @param timestamp the time at which the purchase happened.
+     */
+    public fun purchasedObjectIDs(
+        eventName: String,
+        objectIDs: List<String>,
+        objectData: List<ObjectData>? = null,
+        currency: String? = null,
+        value: Value? = null,
+        timestamp: Long? = null,
+    )
+
+    /**
+     * Tracks a Purchase event after a search has been done.
+     *
+     * @param eventName the event's name, **must not be empty**.
+     * @param queryID the related query's identifier.
+     * @param objectIDs the purchased object(s)' `objectID`.
+     * @param objectData extra information about the purchased items (price, quantity, discount, per-item queryID).
+     * @param currency three-letter [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) currency code.
+     * @param value total monetary value of this event in units of [currency].
+     * @param timestamp the time at which the purchase happened.
+     */
+    public fun purchasedObjectIDsAfterSearch(
+        eventName: String,
+        queryID: String,
+        objectIDs: List<String>,
+        objectData: List<ObjectDataAfterSearch>? = null,
+        currency: String? = null,
+        value: Value? = null,
+        timestamp: Long? = null,
+    )
+
+    /**
+     * Tracks an Add to Cart event, unrelated to a specific search query.
+     *
+     * @param eventName the event's name, **must not be empty**.
+     * @param objectIDs the added object(s)' `objectID`.
+     * @param objectData extra information about the added items (price, quantity, discount).
+     * @param currency three-letter [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) currency code.
+     * @param value total monetary value of this event in units of [currency].
+     * @param timestamp the time at which the add-to-cart happened.
+     */
+    public fun addedToCartObjectIDs(
+        eventName: String,
+        objectIDs: List<String>,
+        objectData: List<ObjectData>? = null,
+        currency: String? = null,
+        value: Value? = null,
+        timestamp: Long? = null,
+    )
+
+    /**
+     * Tracks an Add to Cart event after a search has been done.
+     *
+     * @param eventName the event's name, **must not be empty**.
+     * @param queryID the related query's identifier.
+     * @param objectIDs the added object(s)' `objectID`.
+     * @param objectData extra information about the added items (price, quantity, discount, per-item queryID).
+     * @param currency three-letter [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) currency code.
+     * @param value total monetary value of this event in units of [currency].
+     * @param timestamp the time at which the add-to-cart happened.
+     */
+    public fun addedToCartObjectIDsAfterSearch(
+        eventName: String,
+        queryID: String,
+        objectIDs: List<String>,
+        objectData: List<ObjectDataAfterSearch>? = null,
+        currency: String? = null,
+        value: Value? = null,
         timestamp: Long? = null,
     )
 }

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/InsightsController.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/InsightsController.kt
@@ -1,11 +1,18 @@
 
 package com.algolia.instantsearch.insights.internal
 
+import com.algolia.client.model.insights.ObjectData
+import com.algolia.client.model.insights.ObjectDataAfterSearch
+import com.algolia.client.model.insights.Value
 import com.algolia.instantsearch.insights.Insights
 import com.algolia.instantsearch.insights.internal.cache.InsightsCache
 import com.algolia.instantsearch.insights.internal.data.local.mapper.FilterFacetMapper
+import com.algolia.instantsearch.insights.internal.data.local.mapper.toObjectDataDO
+import com.algolia.instantsearch.insights.internal.data.local.mapper.toDouble
 import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO
+import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO.EventSubtype
 import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO.EventType
+import com.algolia.instantsearch.insights.internal.data.local.model.ObjectDataDO
 import com.algolia.instantsearch.insights.internal.extension.currentTimeMillis
 import com.algolia.instantsearch.insights.internal.extension.randomUUID
 import com.algolia.instantsearch.insights.internal.logging.InsightsLogger
@@ -102,6 +109,80 @@ internal class InsightsController(
         timestamp: Long?,
     ) = track(buildEventDO(EventType.Conversion, eventName, timestamp, queryID, objectIDs))
 
+    override fun purchasedObjectIDs(
+        eventName: String,
+        objectIDs: List<String>,
+        objectData: List<ObjectData>?,
+        currency: String?,
+        value: Value?,
+        timestamp: Long?,
+    ) = track(
+        buildEventDO(
+            EventType.Conversion, eventName, timestamp,
+            objectIDs = objectIDs,
+            eventSubtype = EventSubtype.Purchase,
+            objectDataDO = objectData?.map { it.toObjectDataDO() },
+            currency = currency,
+            valueDouble = value?.toDouble(),
+        )
+    )
+
+    override fun purchasedObjectIDsAfterSearch(
+        eventName: String,
+        queryID: String,
+        objectIDs: List<String>,
+        objectData: List<ObjectDataAfterSearch>?,
+        currency: String?,
+        value: Value?,
+        timestamp: Long?,
+    ) = track(
+        buildEventDO(
+            EventType.Conversion, eventName, timestamp, queryID,
+            objectIDs = objectIDs,
+            eventSubtype = EventSubtype.Purchase,
+            objectDataDO = objectData?.map { it.toObjectDataDO() },
+            currency = currency,
+            valueDouble = value?.toDouble(),
+        )
+    )
+
+    override fun addedToCartObjectIDs(
+        eventName: String,
+        objectIDs: List<String>,
+        objectData: List<ObjectData>?,
+        currency: String?,
+        value: Value?,
+        timestamp: Long?,
+    ) = track(
+        buildEventDO(
+            EventType.Conversion, eventName, timestamp,
+            objectIDs = objectIDs,
+            eventSubtype = EventSubtype.AddToCart,
+            objectDataDO = objectData?.map { it.toObjectDataDO() },
+            currency = currency,
+            valueDouble = value?.toDouble(),
+        )
+    )
+
+    override fun addedToCartObjectIDsAfterSearch(
+        eventName: String,
+        queryID: String,
+        objectIDs: List<String>,
+        objectData: List<ObjectDataAfterSearch>?,
+        currency: String?,
+        value: Value?,
+        timestamp: Long?,
+    ) = track(
+        buildEventDO(
+            EventType.Conversion, eventName, timestamp, queryID,
+            objectIDs = objectIDs,
+            eventSubtype = EventSubtype.AddToCart,
+            objectDataDO = objectData?.map { it.toObjectDataDO() },
+            currency = currency,
+            valueDouble = value?.toDouble(),
+        )
+    )
+
     fun track(event: InsightsEventDO) {
         val insightEvent = effectiveEvent(event)
         if (enabled) {
@@ -122,6 +203,10 @@ internal class InsightsController(
         objectIDs: List<String>? = null,
         positions: List<Int>? = null,
         filters: List<Filter.Facet>? = null,
+        eventSubtype: EventSubtype? = null,
+        objectDataDO: List<ObjectDataDO>? = null,
+        currency: String? = null,
+        valueDouble: Double? = null,
     ): InsightsEventDO {
         val builder = InsightsEventDO.Builder().apply {
             this.eventType = eventType
@@ -133,6 +218,10 @@ internal class InsightsController(
             this.objectIDs = objectIDs
             this.positions = positions
             this.filters = filters?.map { FilterFacetMapper.map(it) }
+            this.eventSubtype = eventSubtype
+            this.objectData = objectDataDO
+            this.currency = currency
+            this.value = valueDouble
         }
         return builder.build()
     }

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/mapper/InsightsEventsMapper.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/mapper/InsightsEventsMapper.kt
@@ -56,7 +56,7 @@ internal object InsightsEventsMapper {
                 builder.eventType = Conversion
                 builder.eventSubtype = EventSubtype.Purchase
                 builder.objectIDs = input.value.objectIDs
-                builder.queryID = input.value.queryID
+                builder.queryID = input.value.objectData.firstNotNullOfOrNull { it.queryID }
                 builder.objectData = input.value.objectData.map { it.toObjectDataDO() }
                 builder.currency = input.value.currency
                 builder.value = input.value.value?.toDouble()

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/mapper/InsightsEventsMapper.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/mapper/InsightsEventsMapper.kt
@@ -3,16 +3,18 @@ package com.algolia.instantsearch.insights.internal.data.local.mapper
 
 import com.algolia.client.model.insights.*
 import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO
+import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO.EventSubtype
 import com.algolia.instantsearch.insights.internal.data.local.model.FilterFacetDO
 import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO.EventType.Click
 import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO.EventType.Conversion
 import com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO.EventType.View
+import com.algolia.instantsearch.insights.internal.data.local.model.ObjectDataDO
 import com.algolia.instantsearch.insights.internal.extension.convertToEventsItem
 import com.algolia.instantsearch.filter.Filter
 
 internal object InsightsEventsMapper {
 
-    fun eventsItemToDO(input: EventsItems): com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO {
+    fun eventsItemToDO(input: EventsItems): InsightsEventDO {
         val builder = InsightsEventDO.Builder()
         when (input) {
             is EventsItems.ViewedObjectIDsValue -> {
@@ -42,7 +44,41 @@ internal object InsightsEventsMapper {
                 builder.eventType = Conversion
                 builder.filters = input.value.filters.mapNotNull(::parseFacetFilter)
             }
-            else -> return builder.build() // Other event types not yet handled
+            is EventsItems.PurchasedObjectIDsValue -> {
+                builder.eventType = Conversion
+                builder.eventSubtype = EventSubtype.Purchase
+                builder.objectIDs = input.value.objectIDs
+                builder.objectData = input.value.objectData?.map { it.toObjectDataDO() }
+                builder.currency = input.value.currency
+                builder.value = input.value.value?.toDouble()
+            }
+            is EventsItems.PurchasedObjectIDsAfterSearchValue -> {
+                builder.eventType = Conversion
+                builder.eventSubtype = EventSubtype.Purchase
+                builder.objectIDs = input.value.objectIDs
+                builder.queryID = input.value.queryID
+                builder.objectData = input.value.objectData.map { it.toObjectDataDO() }
+                builder.currency = input.value.currency
+                builder.value = input.value.value?.toDouble()
+            }
+            is EventsItems.AddedToCartObjectIDsValue -> {
+                builder.eventType = Conversion
+                builder.eventSubtype = EventSubtype.AddToCart
+                builder.objectIDs = input.value.objectIDs
+                builder.objectData = input.value.objectData?.map { it.toObjectDataDO() }
+                builder.currency = input.value.currency
+                builder.value = input.value.value?.toDouble()
+            }
+            is EventsItems.AddedToCartObjectIDsAfterSearchValue -> {
+                builder.eventType = Conversion
+                builder.eventSubtype = EventSubtype.AddToCart
+                builder.objectIDs = input.value.objectIDs
+                builder.queryID = input.value.queryID
+                builder.objectData = input.value.objectData?.map { it.toObjectDataDO() }
+                builder.currency = input.value.currency
+                builder.value = input.value.value?.toDouble()
+            }
+            else -> return builder.build()
         }
         builder.eventName = when (input) {
             is EventsItems.ViewedObjectIDsValue -> input.value.eventName
@@ -51,6 +87,10 @@ internal object InsightsEventsMapper {
             is EventsItems.ClickedFiltersValue -> input.value.eventName
             is EventsItems.ConvertedObjectIDsAfterSearchValue -> input.value.eventName
             is EventsItems.ConvertedFiltersValue -> input.value.eventName
+            is EventsItems.PurchasedObjectIDsValue -> input.value.eventName
+            is EventsItems.PurchasedObjectIDsAfterSearchValue -> input.value.eventName
+            is EventsItems.AddedToCartObjectIDsValue -> input.value.eventName
+            is EventsItems.AddedToCartObjectIDsAfterSearchValue -> input.value.eventName
             else -> ""
         }
         builder.indexName = when (input) {
@@ -60,6 +100,10 @@ internal object InsightsEventsMapper {
             is EventsItems.ClickedFiltersValue -> input.value.index
             is EventsItems.ConvertedObjectIDsAfterSearchValue -> input.value.index
             is EventsItems.ConvertedFiltersValue -> input.value.index
+            is EventsItems.PurchasedObjectIDsValue -> input.value.index
+            is EventsItems.PurchasedObjectIDsAfterSearchValue -> input.value.index
+            is EventsItems.AddedToCartObjectIDsValue -> input.value.index
+            is EventsItems.AddedToCartObjectIDsAfterSearchValue -> input.value.index
             else -> ""
         }
         builder.userToken = when (input) {
@@ -69,6 +113,10 @@ internal object InsightsEventsMapper {
             is EventsItems.ClickedFiltersValue -> input.value.userToken
             is EventsItems.ConvertedObjectIDsAfterSearchValue -> input.value.userToken
             is EventsItems.ConvertedFiltersValue -> input.value.userToken
+            is EventsItems.PurchasedObjectIDsValue -> input.value.userToken
+            is EventsItems.PurchasedObjectIDsAfterSearchValue -> input.value.userToken
+            is EventsItems.AddedToCartObjectIDsValue -> input.value.userToken
+            is EventsItems.AddedToCartObjectIDsAfterSearchValue -> input.value.userToken
             else -> null
         }
         builder.timestamp = when (input) {
@@ -78,12 +126,16 @@ internal object InsightsEventsMapper {
             is EventsItems.ClickedFiltersValue -> input.value.timestamp
             is EventsItems.ConvertedObjectIDsAfterSearchValue -> input.value.timestamp
             is EventsItems.ConvertedFiltersValue -> input.value.timestamp
+            is EventsItems.PurchasedObjectIDsValue -> input.value.timestamp
+            is EventsItems.PurchasedObjectIDsAfterSearchValue -> input.value.timestamp
+            is EventsItems.AddedToCartObjectIDsValue -> input.value.timestamp
+            is EventsItems.AddedToCartObjectIDsAfterSearchValue -> input.value.timestamp
             else -> null
         }
         return builder.build()
     }
 
-    fun doToEventsItem(input: com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO): EventsItems? {
+    fun doToEventsItem(input: InsightsEventDO): EventsItems? {
         return convertToEventsItem(
             eventName = input.eventName,
             indexName = input.indexName,
@@ -92,12 +144,20 @@ internal object InsightsEventsMapper {
                 Click -> "click"
                 Conversion -> "conversion"
             },
+            eventSubtype = when (input.eventSubtype) {
+                EventSubtype.Purchase -> "purchase"
+                EventSubtype.AddToCart -> "addToCart"
+                null -> null
+            },
             userToken = input.userToken,
             timestamp = input.timestamp,
             queryID = input.queryID,
             objectIDs = input.objectIDs,
             positions = input.positions,
-            filters = input.filters?.map { FilterFacetMapper.unmap(it) }
+            filters = input.filters?.map { FilterFacetMapper.unmap(it) },
+            objectData = input.objectData,
+            currency = input.currency,
+            value = input.value,
         )
     }
 
@@ -156,3 +216,31 @@ internal object InsightsEventsMapper {
 
     private val SCORE_REGEX = Regex("<score=(\\d+)>\\s*$")
 }
+
+private fun Price.toDouble(): Double = when (this) {
+    is Price.DoubleValue -> value
+    is Price.StringValue -> value.toDoubleOrNull() ?: 0.0
+}
+
+private fun Discount.toDouble(): Double = when (this) {
+    is Discount.DoubleValue -> value
+    is Discount.StringValue -> value.toDoubleOrNull() ?: 0.0
+}
+
+internal fun Value.toDouble(): Double = when (this) {
+    is Value.DoubleValue -> value
+    is Value.StringValue -> value.toDoubleOrNull() ?: 0.0
+}
+
+internal fun ObjectData.toObjectDataDO(): ObjectDataDO = ObjectDataDO(
+    price = price?.toDouble(),
+    quantity = quantity,
+    discount = discount?.toDouble(),
+)
+
+internal fun ObjectDataAfterSearch.toObjectDataDO(): ObjectDataDO = ObjectDataDO(
+    queryID = queryID,
+    price = price?.toDouble(),
+    quantity = quantity,
+    discount = discount?.toDouble(),
+)

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/model/InsightsEventDO.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/model/InsightsEventDO.kt
@@ -13,7 +13,11 @@ internal data class InsightsEventDO(
     @SerialName("queryID") val queryID: String? = null,
     @SerialName("objectIDs") val objectIDs: List<String>? = null,
     @SerialName("positions") val positions: List<Int>? = null,
-    @SerialName("filters") val filters: List<FilterFacetDO>? = null
+    @SerialName("filters") val filters: List<FilterFacetDO>? = null,
+    @SerialName("eventSubtype") val eventSubtype: EventSubtype? = null,
+    @SerialName("objectData") val objectData: List<ObjectDataDO>? = null,
+    @SerialName("currency") val currency: String? = null,
+    @SerialName("value") val value: Double? = null,
 ) {
 
     @Serializable
@@ -28,6 +32,15 @@ internal data class InsightsEventDO(
         Conversion;
     }
 
+    @Serializable
+    internal enum class EventSubtype {
+        @SerialName("purchase")
+        Purchase,
+
+        @SerialName("addToCart")
+        AddToCart;
+    }
+
     class Builder {
         var eventType: EventType? = null
         var eventName: String? = null
@@ -38,8 +51,12 @@ internal data class InsightsEventDO(
         var objectIDs: List<String>? = null
         var positions: List<Int>? = null
         var filters: List<FilterFacetDO>? = null
+        var eventSubtype: EventSubtype? = null
+        var objectData: List<ObjectDataDO>? = null
+        var currency: String? = null
+        var value: Double? = null
 
-        fun build(): com.algolia.instantsearch.insights.internal.data.local.model.InsightsEventDO = InsightsEventDO(
+        fun build(): InsightsEventDO = InsightsEventDO(
             eventType ?: error("eventType can't not be null"),
             eventName ?: error("eventName can't not be null"),
             indexName ?: error("indexName can't not be null"),
@@ -48,7 +65,11 @@ internal data class InsightsEventDO(
             queryID,
             objectIDs,
             positions,
-            filters
+            filters,
+            eventSubtype,
+            objectData,
+            currency,
+            value,
         )
     }
 }

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/model/ObjectDataDO.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/data/local/model/ObjectDataDO.kt
@@ -1,0 +1,12 @@
+package com.algolia.instantsearch.insights.internal.data.local.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class ObjectDataDO(
+    @SerialName("queryID") val queryID: String? = null,
+    @SerialName("price") val price: Double? = null,
+    @SerialName("quantity") val quantity: Int? = null,
+    @SerialName("discount") val discount: Double? = null,
+)

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/EventsItems.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/EventsItems.kt
@@ -60,22 +60,22 @@ private fun convertViewEvent(
     objectIDs: List<String>?,
     filters: List<Filter.Facet>?,
 ): EventsItems? = when {
-    objectIDs != null -> ViewedObjectIDs(
+    objectIDs != null -> EventsItems.of(ViewedObjectIDs(
         eventName = eventName,
         eventType = ViewEvent.View,
         index = indexName,
         objectIDs = objectIDs,
         userToken = userToken,
         timestamp = timestamp,
-    )
-    filters != null -> ViewedFilters(
+    ))
+    filters != null -> EventsItems.of(ViewedFilters(
         eventName = eventName,
         eventType = ViewEvent.View,
         index = indexName,
         filters = filters.toFilterStrings(),
         userToken = userToken,
         timestamp = timestamp,
-    )
+    ))
     else -> null
 }
 
@@ -89,7 +89,7 @@ private fun convertClickEvent(
     positions: List<Int>?,
     filters: List<Filter.Facet>?,
 ): EventsItems? = when {
-    queryID != null && objectIDs != null && positions != null -> ClickedObjectIDsAfterSearch(
+    queryID != null && objectIDs != null && positions != null -> EventsItems.of(ClickedObjectIDsAfterSearch(
         eventName = eventName,
         eventType = ClickEvent.Click,
         index = indexName,
@@ -98,15 +98,15 @@ private fun convertClickEvent(
         queryID = queryID,
         userToken = userToken,
         timestamp = timestamp,
-    )
-    filters != null -> ClickedFilters(
+    ))
+    filters != null -> EventsItems.of(ClickedFilters(
         eventName = eventName,
         eventType = ClickEvent.Click,
         index = indexName,
         filters = filters.toFilterStrings(),
         userToken = userToken,
         timestamp = timestamp,
-    )
+    ))
     else -> null
 }
 
@@ -137,7 +137,7 @@ private fun convertPlainConversionEvent(
     objectIDs: List<String>?,
     filters: List<Filter.Facet>?,
 ): EventsItems? = when {
-    queryID != null && objectIDs != null -> ConvertedObjectIDsAfterSearch(
+    queryID != null && objectIDs != null -> EventsItems.of(ConvertedObjectIDsAfterSearch(
         eventName = eventName,
         eventType = ConversionEvent.Conversion,
         index = indexName,
@@ -145,15 +145,15 @@ private fun convertPlainConversionEvent(
         queryID = queryID,
         userToken = userToken,
         timestamp = timestamp,
-    )
-    filters != null -> ConvertedFilters(
+    ))
+    filters != null -> EventsItems.of(ConvertedFilters(
         eventName = eventName,
         eventType = ConversionEvent.Conversion,
         index = indexName,
         filters = filters.toFilterStrings(),
         userToken = userToken,
         timestamp = timestamp,
-    )
+    ))
     else -> null
 }
 
@@ -172,7 +172,7 @@ private fun convertPurchaseEvent(
     return if (queryID != null) {
         val mappedObjectData = objectData?.map { it.toObjectDataAfterSearch() }
             ?: objectIDs.map { ObjectDataAfterSearch(queryID = queryID) }
-        PurchasedObjectIDsAfterSearch(
+        EventsItems.of(PurchasedObjectIDsAfterSearch(
             eventName = eventName,
             eventType = ConversionEvent.Conversion,
             eventSubtype = PurchaseEvent.Purchase,
@@ -183,9 +183,9 @@ private fun convertPurchaseEvent(
             timestamp = timestamp,
             currency = currency,
             value = value,
-        )
+        ))
     } else {
-        PurchasedObjectIDs(
+        EventsItems.of(PurchasedObjectIDs(
             eventName = eventName,
             eventType = ConversionEvent.Conversion,
             eventSubtype = PurchaseEvent.Purchase,
@@ -196,7 +196,7 @@ private fun convertPurchaseEvent(
             timestamp = timestamp,
             currency = currency,
             value = value,
-        )
+        ))
     }
 }
 
@@ -213,7 +213,7 @@ private fun convertAddToCartEvent(
 ): EventsItems? {
     if (objectIDs == null) return null
     return if (queryID != null) {
-        AddedToCartObjectIDsAfterSearch(
+        EventsItems.of(AddedToCartObjectIDsAfterSearch(
             eventName = eventName,
             eventType = ConversionEvent.Conversion,
             eventSubtype = AddToCartEvent.AddToCart,
@@ -225,9 +225,9 @@ private fun convertAddToCartEvent(
             timestamp = timestamp,
             currency = currency,
             value = value,
-        )
+        ))
     } else {
-        AddedToCartObjectIDs(
+        EventsItems.of(AddedToCartObjectIDs(
             eventName = eventName,
             eventType = ConversionEvent.Conversion,
             eventSubtype = AddToCartEvent.AddToCart,
@@ -238,7 +238,7 @@ private fun convertAddToCartEvent(
             timestamp = timestamp,
             currency = currency,
             value = value,
-        )
+        ))
     }
 }
 

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/EventsItems.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/EventsItems.kt
@@ -3,6 +3,7 @@ package com.algolia.instantsearch.insights.internal.extension
 import com.algolia.client.model.insights.*
 import com.algolia.instantsearch.filter.Filter
 import com.algolia.instantsearch.filter.FilterConverter
+import com.algolia.instantsearch.insights.internal.data.local.model.ObjectDataDO
 
 /**
  * Converts Filter.Facet to v3 filter string format (facet:value)
@@ -26,94 +27,229 @@ internal fun convertToEventsItem(
     eventName: String,
     indexName: String,
     eventType: String, // "view", "click", "conversion"
+    eventSubtype: String?, // "purchase", "addToCart"
     userToken: String?,
     timestamp: Long?,
     queryID: String?,
     objectIDs: List<String>?,
     positions: List<Int>?,
     filters: List<Filter.Facet>?,
+    objectData: List<ObjectDataDO>?,
+    currency: String?,
+    value: Double?,
 ): EventsItems? {
     val userTokenValue = userToken ?: return null
+    val valueWrapped = value?.let { Value.of(it) }
 
     return when (eventType) {
-        "view" -> {
-            when {
-                objectIDs != null -> {
-                    ViewedObjectIDs(
-                        eventName = eventName,
-                        eventType = ViewEvent.View,
-                        index = indexName,
-                        objectIDs = objectIDs,
-                        userToken = userTokenValue,
-                        timestamp = timestamp
-                    )
-                }
-                filters != null -> {
-                    ViewedFilters(
-                        eventName = eventName,
-                        eventType = ViewEvent.View,
-                        index = indexName,
-                        filters = filters.toFilterStrings(),
-                        userToken = userTokenValue,
-                        timestamp = timestamp
-                    )
-                }
-                else -> null
-            }
-        }
-        "click" -> {
-            when {
-                queryID != null && objectIDs != null && positions != null -> {
-                    ClickedObjectIDsAfterSearch(
-                        eventName = eventName,
-                        eventType = ClickEvent.Click,
-                        index = indexName,
-                        objectIDs = objectIDs,
-                        positions = positions,
-                        queryID = queryID,
-                        userToken = userTokenValue,
-                        timestamp = timestamp
-                    )
-                }
-                filters != null -> {
-                    ClickedFilters(
-                        eventName = eventName,
-                        eventType = ClickEvent.Click,
-                        index = indexName,
-                        filters = filters.toFilterStrings(),
-                        userToken = userTokenValue,
-                        timestamp = timestamp
-                    )
-                }
-                else -> null
-            }
-        }
-        "conversion" -> {
-            when {
-                queryID != null && objectIDs != null -> {
-                    ConvertedObjectIDsAfterSearch(
-                        eventName = eventName,
-                        eventType = ConversionEvent.Conversion,
-                        index = indexName,
-                        objectIDs = objectIDs,
-                        queryID = queryID,
-                        userToken = userTokenValue,
-                        timestamp = timestamp
-                    )
-                }
-                filters != null -> {
-                    ConvertedFilters(
-                        eventName = eventName,
-                        eventType = ConversionEvent.Conversion,
-                        index = indexName,
-                        filters = filters.toFilterStrings(),
-                        userToken = userTokenValue,
-                        timestamp = timestamp
-                    )
-                }
-                else -> null
-            }
-        }
+        "view" -> convertViewEvent(eventName, indexName, userTokenValue, timestamp, objectIDs, filters)
+        "click" -> convertClickEvent(eventName, indexName, userTokenValue, timestamp, queryID, objectIDs, positions, filters)
+        "conversion" -> convertConversionEvent(
+            eventName, indexName, eventSubtype, userTokenValue, timestamp,
+            queryID, objectIDs, filters, objectData, currency, valueWrapped
+        )
         else -> null
     }
 }
+
+private fun convertViewEvent(
+    eventName: String,
+    indexName: String,
+    userToken: String,
+    timestamp: Long?,
+    objectIDs: List<String>?,
+    filters: List<Filter.Facet>?,
+): EventsItems? = when {
+    objectIDs != null -> ViewedObjectIDs(
+        eventName = eventName,
+        eventType = ViewEvent.View,
+        index = indexName,
+        objectIDs = objectIDs,
+        userToken = userToken,
+        timestamp = timestamp,
+    )
+    filters != null -> ViewedFilters(
+        eventName = eventName,
+        eventType = ViewEvent.View,
+        index = indexName,
+        filters = filters.toFilterStrings(),
+        userToken = userToken,
+        timestamp = timestamp,
+    )
+    else -> null
+}
+
+private fun convertClickEvent(
+    eventName: String,
+    indexName: String,
+    userToken: String,
+    timestamp: Long?,
+    queryID: String?,
+    objectIDs: List<String>?,
+    positions: List<Int>?,
+    filters: List<Filter.Facet>?,
+): EventsItems? = when {
+    queryID != null && objectIDs != null && positions != null -> ClickedObjectIDsAfterSearch(
+        eventName = eventName,
+        eventType = ClickEvent.Click,
+        index = indexName,
+        objectIDs = objectIDs,
+        positions = positions,
+        queryID = queryID,
+        userToken = userToken,
+        timestamp = timestamp,
+    )
+    filters != null -> ClickedFilters(
+        eventName = eventName,
+        eventType = ClickEvent.Click,
+        index = indexName,
+        filters = filters.toFilterStrings(),
+        userToken = userToken,
+        timestamp = timestamp,
+    )
+    else -> null
+}
+
+private fun convertConversionEvent(
+    eventName: String,
+    indexName: String,
+    eventSubtype: String?,
+    userToken: String,
+    timestamp: Long?,
+    queryID: String?,
+    objectIDs: List<String>?,
+    filters: List<Filter.Facet>?,
+    objectData: List<ObjectDataDO>?,
+    currency: String?,
+    value: Value?,
+): EventsItems? = when (eventSubtype) {
+    "purchase" -> convertPurchaseEvent(eventName, indexName, userToken, timestamp, queryID, objectIDs, objectData, currency, value)
+    "addToCart" -> convertAddToCartEvent(eventName, indexName, userToken, timestamp, queryID, objectIDs, objectData, currency, value)
+    else -> convertPlainConversionEvent(eventName, indexName, userToken, timestamp, queryID, objectIDs, filters)
+}
+
+private fun convertPlainConversionEvent(
+    eventName: String,
+    indexName: String,
+    userToken: String,
+    timestamp: Long?,
+    queryID: String?,
+    objectIDs: List<String>?,
+    filters: List<Filter.Facet>?,
+): EventsItems? = when {
+    queryID != null && objectIDs != null -> ConvertedObjectIDsAfterSearch(
+        eventName = eventName,
+        eventType = ConversionEvent.Conversion,
+        index = indexName,
+        objectIDs = objectIDs,
+        queryID = queryID,
+        userToken = userToken,
+        timestamp = timestamp,
+    )
+    filters != null -> ConvertedFilters(
+        eventName = eventName,
+        eventType = ConversionEvent.Conversion,
+        index = indexName,
+        filters = filters.toFilterStrings(),
+        userToken = userToken,
+        timestamp = timestamp,
+    )
+    else -> null
+}
+
+private fun convertPurchaseEvent(
+    eventName: String,
+    indexName: String,
+    userToken: String,
+    timestamp: Long?,
+    queryID: String?,
+    objectIDs: List<String>?,
+    objectData: List<ObjectDataDO>?,
+    currency: String?,
+    value: Value?,
+): EventsItems? {
+    if (objectIDs == null) return null
+    return if (queryID != null) {
+        PurchasedObjectIDsAfterSearch(
+            eventName = eventName,
+            eventType = ConversionEvent.Conversion,
+            eventSubtype = PurchaseEvent.Purchase,
+            index = indexName,
+            objectIDs = objectIDs,
+            queryID = queryID,
+            userToken = userToken,
+            objectData = objectData?.map { it.toObjectDataAfterSearch() } ?: objectIDs.map { ObjectDataAfterSearch() },
+            timestamp = timestamp,
+            currency = currency,
+            value = value,
+        )
+    } else {
+        PurchasedObjectIDs(
+            eventName = eventName,
+            eventType = ConversionEvent.Conversion,
+            eventSubtype = PurchaseEvent.Purchase,
+            index = indexName,
+            objectIDs = objectIDs,
+            userToken = userToken,
+            objectData = objectData?.map { it.toObjectData() },
+            timestamp = timestamp,
+            currency = currency,
+            value = value,
+        )
+    }
+}
+
+private fun convertAddToCartEvent(
+    eventName: String,
+    indexName: String,
+    userToken: String,
+    timestamp: Long?,
+    queryID: String?,
+    objectIDs: List<String>?,
+    objectData: List<ObjectDataDO>?,
+    currency: String?,
+    value: Value?,
+): EventsItems? {
+    if (objectIDs == null) return null
+    return if (queryID != null) {
+        AddedToCartObjectIDsAfterSearch(
+            eventName = eventName,
+            eventType = ConversionEvent.Conversion,
+            eventSubtype = AddToCartEvent.AddToCart,
+            index = indexName,
+            objectIDs = objectIDs,
+            queryID = queryID,
+            userToken = userToken,
+            objectData = objectData?.map { it.toObjectDataAfterSearch() },
+            timestamp = timestamp,
+            currency = currency,
+            value = value,
+        )
+    } else {
+        AddedToCartObjectIDs(
+            eventName = eventName,
+            eventType = ConversionEvent.Conversion,
+            eventSubtype = AddToCartEvent.AddToCart,
+            index = indexName,
+            objectIDs = objectIDs,
+            userToken = userToken,
+            objectData = objectData?.map { it.toObjectData() },
+            timestamp = timestamp,
+            currency = currency,
+            value = value,
+        )
+    }
+}
+
+internal fun ObjectDataDO.toObjectData(): ObjectData = ObjectData(
+    price = price?.let { Price.of(it) },
+    quantity = quantity,
+    discount = discount?.let { Discount.of(it) },
+)
+
+internal fun ObjectDataDO.toObjectDataAfterSearch(): ObjectDataAfterSearch = ObjectDataAfterSearch(
+    queryID = queryID,
+    price = price?.let { Price.of(it) },
+    quantity = quantity,
+    discount = discount?.let { Discount.of(it) },
+)

--- a/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/EventsItems.kt
+++ b/instantsearch-insights/src/commonMain/kotlin/com/algolia/instantsearch/insights/internal/extension/EventsItems.kt
@@ -170,15 +170,16 @@ private fun convertPurchaseEvent(
 ): EventsItems? {
     if (objectIDs == null) return null
     return if (queryID != null) {
+        val mappedObjectData = objectData?.map { it.toObjectDataAfterSearch() }
+            ?: objectIDs.map { ObjectDataAfterSearch(queryID = queryID) }
         PurchasedObjectIDsAfterSearch(
             eventName = eventName,
             eventType = ConversionEvent.Conversion,
             eventSubtype = PurchaseEvent.Purchase,
             index = indexName,
             objectIDs = objectIDs,
-            queryID = queryID,
             userToken = userToken,
-            objectData = objectData?.map { it.toObjectDataAfterSearch() } ?: objectIDs.map { ObjectDataAfterSearch() },
+            objectData = mappedObjectData,
             timestamp = timestamp,
             currency = currency,
             value = value,

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/tracker/HitsTracker.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/tracker/HitsTracker.kt
@@ -44,6 +44,22 @@ public interface HitsTracker : Connection {
      * @param customEventName custom event name, overrides the default event name
      */
     public fun <T : Indexable> trackView(hit: T, customEventName: String? = null)
+
+    /**
+     * Track a hit purchase event after search.
+     *
+     * @param hit hit to track
+     * @param customEventName custom event name, overrides the default event name
+     */
+    public fun <T : Indexable> trackPurchase(hit: T, customEventName: String? = null)
+
+    /**
+     * Track a hit add-to-cart event after search.
+     *
+     * @param hit hit to track
+     * @param customEventName custom event name, overrides the default event name
+     */
+    public fun <T : Indexable> trackAddToCart(hit: T, customEventName: String? = null)
 }
 
 /**

--- a/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/tracker/internal/HitsDataTracker.kt
+++ b/instantsearch/src/commonMain/kotlin/com/algolia/instantsearch/tracker/internal/HitsDataTracker.kt
@@ -54,6 +54,28 @@ internal class HitsDataTracker(
             )
         }
     }
+
+    override fun <T : Indexable> trackPurchase(hit: T, customEventName: String?) {
+        trackerScope.launch {
+            val id = queryID ?: return@launch
+            tracker.purchasedObjectIDsAfterSearch(
+                eventName = customEventName ?: eventName,
+                queryID = id,
+                objectIDs = listOf(hit.objectID),
+            )
+        }
+    }
+
+    override fun <T : Indexable> trackAddToCart(hit: T, customEventName: String?) {
+        trackerScope.launch {
+            val id = queryID ?: return@launch
+            tracker.addedToCartObjectIDsAfterSearch(
+                eventName = customEventName ?: eventName,
+                queryID = id,
+                objectIDs = listOf(hit.objectID),
+            )
+        }
+    }
     // endregion
 
     override var isConnected: Boolean = false


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no
| Related Issue     | 
| Need Doc update   | yes/


## Describe your change

Add event subtype support (purchase and add-to-cart) to Insights
The Algolia Insights API supports event subtypes (purchase, addToCart)
on conversion events, but the InstantSearch Insights abstraction layer
did not surface them. This change adds first-class support across all
layers.
Internal data model:
- Add EventSubtype enum (Purchase, AddToCart) and new fields
  (eventSubtype, objectData, currency, value) to InsightsEventDO
- Add ObjectDataDO for persisting per-object revenue data (price,
  quantity, discount)
Mapper layer:
- Extend convertToEventsItem to route conversion events with subtypes
  to PurchasedObjectIDs(AfterSearch) and AddedToCartObjectIDs(AfterSearch)
- Extend InsightsEventsMapper to handle all 4 new EventsItems variants
  in both directions (DO <-> API client types)
Public API:
- Add 4 new methods to HitsAfterSearchTrackable: purchasedObjectIDs,
  purchasedObjectIDsAfterSearch, addedToCartObjectIDs,
  addedToCartObjectIDsAfterSearch — with optional objectData, currency,
  and value parameters using the API client's existing types
- Add trackPurchase and trackAddToCart convenience methods to
  HitsTracker for after-search scenarios
Tests:
- HTTP send tests for purchase and add-to-cart events
- Controller tests verifying index name, subtype, and queryID storage
- ObjectData round-trip test through the controller
- Mapper round-trip tests for both subtypes with and without queryID